### PR TITLE
ORC-1347: [C++] use make_unique/make_shared when possible

### DIFF
--- a/c++/src/BloomFilter.cc
+++ b/c++/src/BloomFilter.cc
@@ -298,25 +298,22 @@ namespace orc {
   std::unique_ptr<BloomFilter> BloomFilterUTF8Utils::deserialize(
       const proto::Stream_Kind& streamKind, const proto::ColumnEncoding& encoding,
       const proto::BloomFilter& bloomFilter) {
-    std::unique_ptr<BloomFilter> ret(nullptr);
-
     // only BLOOM_FILTER_UTF8 is supported
     if (streamKind != proto::Stream_Kind_BLOOM_FILTER_UTF8) {
-      return ret;
+      return nullptr;
     }
 
     // make sure we don't use unknown encodings or original timestamp encodings
     if (!encoding.has_bloomencoding() || encoding.bloomencoding() != 1) {
-      return ret;
+      return nullptr;
     }
 
     // make sure all required fields exist
     if (!bloomFilter.has_numhashfunctions() || !bloomFilter.has_utf8bitset()) {
-      return ret;
+      return nullptr;
     }
 
-    ret.reset(new BloomFilterImpl(bloomFilter));
-    return ret;
+    return std::make_unique<BloomFilterImpl>(bloomFilter);
   }
 
 }  // namespace orc

--- a/c++/src/ByteRLE.cc
+++ b/c++/src/ByteRLE.cc
@@ -217,7 +217,7 @@ namespace orc {
 
   std::unique_ptr<ByteRleEncoder> createByteRleEncoder(
       std::unique_ptr<BufferedOutputStream> output) {
-    return std::unique_ptr<ByteRleEncoder>(new ByteRleEncoderImpl(std::move(output)));
+    return std::make_unique<ByteRleEncoderImpl>(std::move(output));
   }
 
   class BooleanRleEncoderImpl : public ByteRleEncoderImpl {
@@ -488,7 +488,7 @@ namespace orc {
 
   std::unique_ptr<ByteRleDecoder> createByteRleDecoder(std::unique_ptr<SeekableInputStream> input,
                                                        ReaderMetrics* metrics) {
-    return std::unique_ptr<ByteRleDecoder>(new ByteRleDecoderImpl(std::move(input), metrics));
+    return std::make_unique<ByteRleDecoderImpl>(std::move(input), metrics);
   }
 
   class BooleanRleDecoderImpl : public ByteRleDecoderImpl {
@@ -626,7 +626,6 @@ namespace orc {
 
   std::unique_ptr<ByteRleDecoder> createBooleanRleDecoder(
       std::unique_ptr<SeekableInputStream> input, ReaderMetrics* metrics) {
-    BooleanRleDecoderImpl* decoder = new BooleanRleDecoderImpl(std::move(input), metrics);
-    return std::unique_ptr<ByteRleDecoder>(reinterpret_cast<ByteRleDecoder*>(decoder));
+    return std::make_unique<BooleanRleDecoderImpl>(std::move(input), metrics);
   }
 }  // namespace orc

--- a/c++/src/ColumnPrinter.cc
+++ b/c++/src/ColumnPrinter.cc
@@ -222,75 +222,75 @@ namespace orc {
   }
 
   std::unique_ptr<ColumnPrinter> createColumnPrinter(std::string& buffer, const Type* type) {
-    ColumnPrinter* result = nullptr;
+    std::unique_ptr<ColumnPrinter> result;
     if (type == nullptr) {
-      result = new VoidColumnPrinter(buffer);
+      result = std::make_unique<VoidColumnPrinter>(buffer);
     } else {
       switch (static_cast<int64_t>(type->getKind())) {
         case BOOLEAN:
-          result = new BooleanColumnPrinter(buffer);
+          result = std::make_unique<BooleanColumnPrinter>(buffer);
           break;
 
         case BYTE:
         case SHORT:
         case INT:
         case LONG:
-          result = new LongColumnPrinter(buffer);
+          result = std::make_unique<LongColumnPrinter>(buffer);
           break;
 
         case FLOAT:
         case DOUBLE:
-          result = new DoubleColumnPrinter(buffer, *type);
+          result = std::make_unique<DoubleColumnPrinter>(buffer, *type);
           break;
 
         case STRING:
         case VARCHAR:
         case CHAR:
-          result = new StringColumnPrinter(buffer);
+          result = std::make_unique<StringColumnPrinter>(buffer);
           break;
 
         case BINARY:
-          result = new BinaryColumnPrinter(buffer);
+          result = std::make_unique<BinaryColumnPrinter>(buffer);
           break;
 
         case TIMESTAMP:
         case TIMESTAMP_INSTANT:
-          result = new TimestampColumnPrinter(buffer);
+          result = std::make_unique<TimestampColumnPrinter>(buffer);
           break;
 
         case LIST:
-          result = new ListColumnPrinter(buffer, *type);
+          result = std::make_unique<ListColumnPrinter>(buffer, *type);
           break;
 
         case MAP:
-          result = new MapColumnPrinter(buffer, *type);
+          result = std::make_unique<MapColumnPrinter>(buffer, *type);
           break;
 
         case STRUCT:
-          result = new StructColumnPrinter(buffer, *type);
+          result = std::make_unique<StructColumnPrinter>(buffer, *type);
           break;
 
         case DECIMAL:
           if (type->getPrecision() == 0 || type->getPrecision() > 18) {
-            result = new Decimal128ColumnPrinter(buffer);
+            result = std::make_unique<Decimal128ColumnPrinter>(buffer);
           } else {
-            result = new Decimal64ColumnPrinter(buffer);
+            result = std::make_unique<Decimal64ColumnPrinter>(buffer);
           }
           break;
 
         case DATE:
-          result = new DateColumnPrinter(buffer);
+          result = std::make_unique<DateColumnPrinter>(buffer);
           break;
 
         case UNION:
-          result = new UnionColumnPrinter(buffer, *type);
+          result = std::make_unique<UnionColumnPrinter>(buffer, *type);
           break;
 
         default:
           throw std::logic_error("unknown batch type");
       }
     }
-    return std::unique_ptr<ColumnPrinter>(result);
+    return result;
   }
 
   VoidColumnPrinter::VoidColumnPrinter(std::string& _buffer) : ColumnPrinter(_buffer) {

--- a/c++/src/ColumnReader.cc
+++ b/c++/src/ColumnReader.cc
@@ -1695,20 +1695,17 @@ namespace orc {
     switch (static_cast<int64_t>(type.getKind())) {
       case SHORT: {
         if (useTightNumericVector) {
-          return std::unique_ptr<ColumnReader>(
-              new IntegerColumnReader<ShortVectorBatch>(type, stripe));
+          return std::make_unique<IntegerColumnReader<ShortVectorBatch>>(type, stripe);
         }
       }
       case INT: {
         if (useTightNumericVector) {
-          return std::unique_ptr<ColumnReader>(
-              new IntegerColumnReader<IntVectorBatch>(type, stripe));
+          return std::make_unique<IntegerColumnReader<IntVectorBatch>>(type, stripe);
         }
       }
       case LONG:
       case DATE:
-        return std::unique_ptr<ColumnReader>(
-            new IntegerColumnReader<LongVectorBatch>(type, stripe));
+        return std::make_unique<IntegerColumnReader<LongVectorBatch>>(type, stripe);
       case BINARY:
       case CHAR:
       case STRING:
@@ -1716,83 +1713,79 @@ namespace orc {
         switch (static_cast<int64_t>(stripe.getEncoding(type.getColumnId()).kind())) {
           case proto::ColumnEncoding_Kind_DICTIONARY:
           case proto::ColumnEncoding_Kind_DICTIONARY_V2:
-            return std::unique_ptr<ColumnReader>(new StringDictionaryColumnReader(type, stripe));
+            return std::make_unique<StringDictionaryColumnReader>(type, stripe);
           case proto::ColumnEncoding_Kind_DIRECT:
           case proto::ColumnEncoding_Kind_DIRECT_V2:
-            return std::unique_ptr<ColumnReader>(new StringDirectColumnReader(type, stripe));
+            return std::make_unique<StringDirectColumnReader>(type, stripe);
           default:
             throw NotImplementedYet("buildReader unhandled string encoding");
         }
 
       case BOOLEAN:
-        return std::unique_ptr<ColumnReader>(new BooleanColumnReader(type, stripe));
+        return std::make_unique<BooleanColumnReader>(type, stripe);
 
       case BYTE:
         if (useTightNumericVector) {
-          return std::unique_ptr<ColumnReader>(new ByteColumnReader<ByteVectorBatch>(type, stripe));
+          return std::make_unique<ByteColumnReader<ByteVectorBatch>>(type, stripe);
         }
-        return std::unique_ptr<ColumnReader>(new ByteColumnReader<LongVectorBatch>(type, stripe));
+        return std::make_unique<ByteColumnReader<LongVectorBatch>>(type, stripe);
 
       case LIST:
-        return std::unique_ptr<ColumnReader>(
-            new ListColumnReader(type, stripe, useTightNumericVector));
+        return std::make_unique<ListColumnReader>(type, stripe, useTightNumericVector);
 
       case MAP:
-        return std::unique_ptr<ColumnReader>(
-            new MapColumnReader(type, stripe, useTightNumericVector));
+        return std::make_unique<MapColumnReader>(type, stripe, useTightNumericVector);
 
       case UNION:
-        return std::unique_ptr<ColumnReader>(
-            new UnionColumnReader(type, stripe, useTightNumericVector));
+        return std::make_unique<UnionColumnReader>(type, stripe, useTightNumericVector);
 
       case STRUCT:
-        return std::unique_ptr<ColumnReader>(
-            new StructColumnReader(type, stripe, useTightNumericVector));
+        return std::make_unique<StructColumnReader>(type, stripe, useTightNumericVector);
 
       case FLOAT: {
         if (useTightNumericVector) {
           if (isLittleEndian()) {
-            return std::unique_ptr<ColumnReader>(
-                new DoubleColumnReader<FLOAT, true, float, FloatVectorBatch>(type, stripe));
+            return std::make_unique<DoubleColumnReader<FLOAT, true, float, FloatVectorBatch>>(
+                type, stripe);
           }
-          return std::unique_ptr<ColumnReader>(
-              new DoubleColumnReader<FLOAT, false, float, FloatVectorBatch>(type, stripe));
+          return std::make_unique<DoubleColumnReader<FLOAT, false, float, FloatVectorBatch>>(
+              type, stripe);
         }
         if (isLittleEndian()) {
-          return std::unique_ptr<ColumnReader>(
-              new DoubleColumnReader<FLOAT, true, double, DoubleVectorBatch>(type, stripe));
+          return std::make_unique<DoubleColumnReader<FLOAT, true, double, DoubleVectorBatch>>(
+              type, stripe);
         }
-        return std::unique_ptr<ColumnReader>(
-            new DoubleColumnReader<FLOAT, false, double, DoubleVectorBatch>(type, stripe));
+        return std::make_unique<DoubleColumnReader<FLOAT, false, double, DoubleVectorBatch>>(
+            type, stripe);
       }
       case DOUBLE: {
         if (isLittleEndian()) {
-          return std::unique_ptr<ColumnReader>(
-              new DoubleColumnReader<DOUBLE, true, double, DoubleVectorBatch>(type, stripe));
+          return std::make_unique<DoubleColumnReader<DOUBLE, true, double, DoubleVectorBatch>>(
+              type, stripe);
         }
-        return std::unique_ptr<ColumnReader>(
-            new DoubleColumnReader<DOUBLE, false, double, DoubleVectorBatch>(type, stripe));
+        return std::make_unique<DoubleColumnReader<DOUBLE, false, double, DoubleVectorBatch>>(
+            type, stripe);
       }
       case TIMESTAMP:
-        return std::unique_ptr<ColumnReader>(new TimestampColumnReader(type, stripe, false));
+        return std::make_unique<TimestampColumnReader>(type, stripe, false);
 
       case TIMESTAMP_INSTANT:
-        return std::unique_ptr<ColumnReader>(new TimestampColumnReader(type, stripe, true));
+        return std::make_unique<TimestampColumnReader>(type, stripe, true);
 
       case DECIMAL:
         // is this a Hive 0.11 or 0.12 file?
         if (type.getPrecision() == 0) {
-          return std::unique_ptr<ColumnReader>(new DecimalHive11ColumnReader(type, stripe));
+          return std::make_unique<DecimalHive11ColumnReader>(type, stripe);
         }
         // can we represent the values using int64_t?
         if (type.getPrecision() <= Decimal64ColumnReader::MAX_PRECISION_64) {
           if (stripe.isDecimalAsLong()) {
-            return std::unique_ptr<ColumnReader>(new Decimal64ColumnReaderV2(type, stripe));
+            return std::make_unique<Decimal64ColumnReaderV2>(type, stripe);
           }
-          return std::unique_ptr<ColumnReader>(new Decimal64ColumnReader(type, stripe));
+          return std::make_unique<Decimal64ColumnReader>(type, stripe);
         }
         // otherwise we use the Int128 implementation
-        return std::unique_ptr<ColumnReader>(new Decimal128ColumnReader(type, stripe));
+        return std::make_unique<Decimal128ColumnReader>(type, stripe);
 
       default:
         throw NotImplementedYet("buildReader unhandled type");

--- a/c++/src/Compression.cc
+++ b/c++/src/Compression.cc
@@ -1148,30 +1148,30 @@ namespace orc {
                                                          MemoryPool& pool, WriterMetrics* metrics) {
     switch (static_cast<int64_t>(kind)) {
       case CompressionKind_NONE: {
-        return std::unique_ptr<BufferedOutputStream>(new BufferedOutputStream(
-            pool, outStream, bufferCapacity, compressionBlockSize, metrics));
+        return std::make_unique<BufferedOutputStream>(pool, outStream, bufferCapacity,
+                                                      compressionBlockSize, metrics);
       }
       case CompressionKind_ZLIB: {
         int level =
             (strategy == CompressionStrategy_SPEED) ? Z_BEST_SPEED + 1 : Z_DEFAULT_COMPRESSION;
-        return std::unique_ptr<BufferedOutputStream>(new ZlibCompressionStream(
-            outStream, level, bufferCapacity, compressionBlockSize, pool, metrics));
+        return std::make_unique<ZlibCompressionStream>(outStream, level, bufferCapacity,
+                                                       compressionBlockSize, pool, metrics);
       }
       case CompressionKind_ZSTD: {
         int level = (strategy == CompressionStrategy_SPEED) ? 1 : ZSTD_CLEVEL_DEFAULT;
-        return std::unique_ptr<BufferedOutputStream>(new ZSTDCompressionStream(
-            outStream, level, bufferCapacity, compressionBlockSize, pool, metrics));
+        return std::make_unique<ZSTDCompressionStream>(outStream, level, bufferCapacity,
+                                                       compressionBlockSize, pool, metrics);
       }
       case CompressionKind_LZ4: {
         int level = (strategy == CompressionStrategy_SPEED) ? LZ4_ACCELERATION_MAX
                                                             : LZ4_ACCELERATION_DEFAULT;
-        return std::unique_ptr<BufferedOutputStream>(new Lz4CompressionSteam(
-            outStream, level, bufferCapacity, compressionBlockSize, pool, metrics));
+        return std::make_unique<Lz4CompressionSteam>(outStream, level, bufferCapacity,
+                                                     compressionBlockSize, pool, metrics);
       }
       case CompressionKind_SNAPPY: {
         int level = 0;
-        return std::unique_ptr<BufferedOutputStream>(new SnappyCompressionStream(
-            outStream, level, bufferCapacity, compressionBlockSize, pool, metrics));
+        return std::make_unique<SnappyCompressionStream>(outStream, level, bufferCapacity,
+                                                         compressionBlockSize, pool, metrics);
       }
       case CompressionKind_LZO:
       default:
@@ -1186,20 +1186,18 @@ namespace orc {
       case CompressionKind_NONE:
         return input;
       case CompressionKind_ZLIB:
-        return std::unique_ptr<SeekableInputStream>(
-            new ZlibDecompressionStream(std::move(input), blockSize, pool, metrics));
+        return std::make_unique<ZlibDecompressionStream>(std::move(input), blockSize, pool,
+                                                         metrics);
       case CompressionKind_SNAPPY:
-        return std::unique_ptr<SeekableInputStream>(
-            new SnappyDecompressionStream(std::move(input), blockSize, pool, metrics));
+        return std::make_unique<SnappyDecompressionStream>(std::move(input), blockSize, pool,
+                                                           metrics);
       case CompressionKind_LZO:
-        return std::unique_ptr<SeekableInputStream>(
-            new LzoDecompressionStream(std::move(input), blockSize, pool, metrics));
+        return std::make_unique<LzoDecompressionStream>(std::move(input), blockSize, pool, metrics);
       case CompressionKind_LZ4:
-        return std::unique_ptr<SeekableInputStream>(
-            new Lz4DecompressionStream(std::move(input), blockSize, pool, metrics));
+        return std::make_unique<Lz4DecompressionStream>(std::move(input), blockSize, pool, metrics);
       case CompressionKind_ZSTD:
-        return std::unique_ptr<SeekableInputStream>(
-            new ZSTDDecompressionStream(std::move(input), blockSize, pool, metrics));
+        return std::make_unique<ZSTDDecompressionStream>(std::move(input), blockSize, pool,
+                                                         metrics);
       default: {
         std::ostringstream buffer;
         buffer << "Unknown compression codec " << kind;

--- a/c++/src/Options.hh
+++ b/c++/src/Options.hh
@@ -52,14 +52,12 @@ namespace orc {
     }
   };
 
-  ReaderOptions::ReaderOptions()
-      : privateBits(std::unique_ptr<ReaderOptionsPrivate>(new ReaderOptionsPrivate())) {
+  ReaderOptions::ReaderOptions() : privateBits(std::make_unique<ReaderOptionsPrivate>()) {
     // PASS
   }
 
   ReaderOptions::ReaderOptions(const ReaderOptions& rhs)
-      : privateBits(std::unique_ptr<ReaderOptionsPrivate>(
-            new ReaderOptionsPrivate(*(rhs.privateBits.get())))) {
+      : privateBits(std::make_unique<ReaderOptionsPrivate>(*(rhs.privateBits.get()))) {
     // PASS
   }
 
@@ -154,14 +152,12 @@ namespace orc {
     }
   };
 
-  RowReaderOptions::RowReaderOptions()
-      : privateBits(std::unique_ptr<RowReaderOptionsPrivate>(new RowReaderOptionsPrivate())) {
+  RowReaderOptions::RowReaderOptions() : privateBits(std::make_unique<RowReaderOptionsPrivate>()) {
     // PASS
   }
 
   RowReaderOptions::RowReaderOptions(const RowReaderOptions& rhs)
-      : privateBits(std::unique_ptr<RowReaderOptionsPrivate>(
-            new RowReaderOptionsPrivate(*(rhs.privateBits.get())))) {
+      : privateBits(std::make_unique<RowReaderOptionsPrivate>(*(rhs.privateBits.get()))) {
     // PASS
   }
 

--- a/c++/src/OrcFile.cc
+++ b/c++/src/OrcFile.cc
@@ -116,7 +116,7 @@ namespace orc {
   DIAGNOSTIC_POP
 
   std::unique_ptr<InputStream> readLocalFile(const std::string& path, ReaderMetrics* metrics) {
-    return std::unique_ptr<InputStream>(new FileInputStream(path, metrics));
+    return std::make_unique<FileInputStream>(path, metrics);
   }
 
   OutputStream::~OutputStream(){
@@ -185,6 +185,6 @@ namespace orc {
   }
 
   std::unique_ptr<OutputStream> writeLocalFile(const std::string& path) {
-    return std::unique_ptr<OutputStream>(new FileOutputStream(path));
+    return std::make_unique<FileOutputStream>(path);
   }
 }  // namespace orc

--- a/c++/src/OrcHdfsFile.cc
+++ b/c++/src/OrcHdfsFile.cc
@@ -173,6 +173,6 @@ namespace orc {
   HdfsFileInputStream::~HdfsFileInputStream() {}
 
   std::unique_ptr<InputStream> readHdfsFile(const std::string& path, ReaderMetrics* metrics) {
-    return std::unique_ptr<InputStream>(new HdfsFileInputStream(path, metrics));
+    return std::make_unique<HdfsFileInputStream>(path, metrics);
   }
 }  // namespace orc

--- a/c++/src/RLE.cc
+++ b/c++/src/RLE.cc
@@ -35,11 +35,9 @@ namespace orc {
                                                bool alignedBitpacking) {
     switch (static_cast<int64_t>(version)) {
       case RleVersion_1:
-        // We don't have std::make_unique() yet.
-        return std::unique_ptr<RleEncoder>(new RleEncoderV1(std::move(output), isSigned));
+        return std::make_unique<RleEncoderV1>(std::move(output), isSigned);
       case RleVersion_2:
-        return std::unique_ptr<RleEncoder>(
-            new RleEncoderV2(std::move(output), isSigned, alignedBitpacking));
+        return std::make_unique<RleEncoderV2>(std::move(output), isSigned, alignedBitpacking);
       default:
         throw NotImplementedYet("Not implemented yet");
     }
@@ -50,11 +48,9 @@ namespace orc {
                                                ReaderMetrics* metrics) {
     switch (static_cast<int64_t>(version)) {
       case RleVersion_1:
-        // We don't have std::make_unique() yet.
-        return std::unique_ptr<RleDecoder>(new RleDecoderV1(std::move(input), isSigned, metrics));
+        return std::make_unique<RleDecoderV1>(std::move(input), isSigned, metrics);
       case RleVersion_2:
-        return std::unique_ptr<RleDecoder>(
-            new RleDecoderV2(std::move(input), isSigned, pool, metrics));
+        return std::make_unique<RleDecoderV2>(std::move(input), isSigned, pool, metrics);
       default:
         throw NotImplementedYet("Not implemented yet");
     }

--- a/c++/src/Statistics.cc
+++ b/c++/src/Statistics.cc
@@ -85,7 +85,7 @@ namespace orc {
       const proto::StripeStatistics& stripeStats,
       std::vector<std::vector<proto::ColumnStatistics> >& indexStats,
       const StatContext& statContext) {
-    columnStats.reset(new StatisticsImpl(stripeStats, statContext));
+    columnStats = std::make_unique<StatisticsImpl>(stripeStats, statContext);
     rowIndexStats.resize(indexStats.size());
     for (size_t i = 0; i < rowIndexStats.size(); i++) {
       for (size_t j = 0; j < indexStats[i].size(); j++) {
@@ -385,34 +385,34 @@ namespace orc {
   std::unique_ptr<MutableColumnStatistics> createColumnStatistics(const Type& type) {
     switch (static_cast<int64_t>(type.getKind())) {
       case BOOLEAN:
-        return std::unique_ptr<MutableColumnStatistics>(new BooleanColumnStatisticsImpl());
+        return std::make_unique<BooleanColumnStatisticsImpl>();
       case BYTE:
       case INT:
       case LONG:
       case SHORT:
-        return std::unique_ptr<MutableColumnStatistics>(new IntegerColumnStatisticsImpl());
+        return std::make_unique<IntegerColumnStatisticsImpl>();
       case MAP:
       case LIST:
-        return std::unique_ptr<MutableColumnStatistics>(new CollectionColumnStatisticsImpl());
+        return std::make_unique<CollectionColumnStatisticsImpl>();
       case STRUCT:
       case UNION:
-        return std::unique_ptr<MutableColumnStatistics>(new ColumnStatisticsImpl());
+        return std::make_unique<ColumnStatisticsImpl>();
       case FLOAT:
       case DOUBLE:
-        return std::unique_ptr<MutableColumnStatistics>(new DoubleColumnStatisticsImpl());
+        return std::make_unique<DoubleColumnStatisticsImpl>();
       case BINARY:
-        return std::unique_ptr<MutableColumnStatistics>(new BinaryColumnStatisticsImpl());
+        return std::make_unique<BinaryColumnStatisticsImpl>();
       case STRING:
       case CHAR:
       case VARCHAR:
-        return std::unique_ptr<MutableColumnStatistics>(new StringColumnStatisticsImpl());
+        return std::make_unique<StringColumnStatisticsImpl>();
       case DATE:
-        return std::unique_ptr<MutableColumnStatistics>(new DateColumnStatisticsImpl());
+        return std::make_unique<DateColumnStatisticsImpl>();
       case TIMESTAMP:
       case TIMESTAMP_INSTANT:
-        return std::unique_ptr<MutableColumnStatistics>(new TimestampColumnStatisticsImpl());
+        return std::make_unique<TimestampColumnStatisticsImpl>();
       case DECIMAL:
-        return std::unique_ptr<MutableColumnStatistics>(new DecimalColumnStatisticsImpl());
+        return std::make_unique<DecimalColumnStatisticsImpl>();
       default:
         throw NotImplementedYet("Not supported type: " + type.toString());
     }

--- a/c++/src/Timezone.cc
+++ b/c++/src/Timezone.cc
@@ -447,9 +447,9 @@ namespace orc {
    * Parse the POSIX TZ string.
    */
   std::shared_ptr<FutureRule> parseFutureRule(const std::string& ruleString) {
-    std::shared_ptr<FutureRule> result(new FutureRuleImpl());
+    auto result = std::make_shared<FutureRuleImpl>();
     FutureRuleParser parser(ruleString, dynamic_cast<FutureRuleImpl*>(result.get()));
-    return result;
+    return std::move(result);
   }
 
   std::string TimezoneVariant::toString() const {
@@ -674,7 +674,7 @@ namespace orc {
       size_t size = static_cast<size_t>(file->getLength());
       std::vector<unsigned char> buffer(size);
       file->read(&buffer[0], size, 0);
-      timezoneCache[filename] = std::shared_ptr<Timezone>(new TimezoneImpl(filename, buffer));
+      timezoneCache[filename] = std::make_shared<TimezoneImpl>(filename, buffer);
     } catch (ParseError& err) {
       throw TimezoneError(err.what());
     }
@@ -708,7 +708,7 @@ namespace orc {
    */
   std::unique_ptr<Timezone> getTimezone(const std::string& filename,
                                         const std::vector<unsigned char>& b) {
-    return std::unique_ptr<Timezone>(new TimezoneImpl(filename, b));
+    return std::make_unique<TimezoneImpl>(filename, b);
   }
 
   TimezoneImpl::~TimezoneImpl() {

--- a/c++/src/sargs/SearchArgument.cc
+++ b/c++/src/sargs/SearchArgument.cc
@@ -582,11 +582,11 @@ namespace orc {
         leafList[newLoc] = leaf.first;
       }
     }
-    return std::unique_ptr<SearchArgument>(new SearchArgumentImpl(mRoot, leafList));
+    return std::make_unique<SearchArgumentImpl>(mRoot, leafList);
   }
 
   std::unique_ptr<SearchArgumentBuilder> SearchArgumentFactory::newBuilder() {
-    return std::unique_ptr<SearchArgumentBuilder>(new SearchArgumentBuilderImpl());
+    return std::make_unique<SearchArgumentBuilderImpl>();
   }
 
 }  // namespace orc

--- a/c++/test/TestAttributes.cc
+++ b/c++/test/TestAttributes.cc
@@ -42,8 +42,8 @@ namespace orc {
     static void TearDownTestCase() {}
 
     std::unique_ptr<Reader> createReader() {
-      std::unique_ptr<InputStream> inStream(
-          new MemoryInputStream(memStream.getData(), memStream.getLength()));
+      auto inStream =
+          std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
       ReaderOptions options;
       return orc::createReader(std::move(inStream), options);
     }

--- a/c++/test/TestByteRLEEncoder.cc
+++ b/c++/test/TestByteRLEEncoder.cc
@@ -59,8 +59,8 @@ namespace orc {
 
   void decodeAndVerify(const MemoryOutputStream& memStream, char* data, uint64_t numValues,
                        char* notNull) {
-    std::unique_ptr<SeekableInputStream> inStream(
-        new SeekableArrayInputStream(memStream.getData(), memStream.getLength()));
+    auto inStream =
+        std::make_unique<SeekableArrayInputStream>(memStream.getData(), memStream.getLength());
 
     std::unique_ptr<ByteRleDecoder> decoder =
         createByteRleDecoder(std::move(inStream), getDefaultReaderMetrics());
@@ -79,8 +79,8 @@ namespace orc {
 
   void decodeAndVerifyBoolean(const MemoryOutputStream& memStream, char* data, uint64_t numValues,
                               char* notNull) {
-    std::unique_ptr<SeekableInputStream> inStream(
-        new SeekableArrayInputStream(memStream.getData(), memStream.getLength()));
+    auto inStream =
+        std::make_unique<SeekableArrayInputStream>(memStream.getData(), memStream.getLength());
 
     std::unique_ptr<ByteRleDecoder> decoder =
         createBooleanRleDecoder(std::move(inStream), getDefaultReaderMetrics());
@@ -107,8 +107,8 @@ namespace orc {
     uint64_t block = 1024;
     BufferedOutputStream bufStream(*pool, &memStream, capacity, block, nullptr);
 
-    std::unique_ptr<BufferedOutputStream> outStream(
-        new BufferedOutputStream(*pool, &memStream, capacity, block, nullptr));
+    auto outStream =
+        std::make_unique<BufferedOutputStream>(*pool, &memStream, capacity, block, nullptr);
 
     std::unique_ptr<ByteRleEncoder> encoder = createByteRleEncoder(std::move(outStream));
 
@@ -129,8 +129,8 @@ namespace orc {
     uint64_t block = 1024;
     BufferedOutputStream bufStream(*pool, &memStream, capacity, block, nullptr);
 
-    std::unique_ptr<BufferedOutputStream> outStream(
-        new BufferedOutputStream(*pool, &memStream, capacity, block, nullptr));
+    auto outStream =
+        std::make_unique<BufferedOutputStream>(*pool, &memStream, capacity, block, nullptr);
 
     std::unique_ptr<ByteRleEncoder> encoder = createByteRleEncoder(std::move(outStream));
 
@@ -153,8 +153,8 @@ namespace orc {
     uint64_t block = 1024;
     BufferedOutputStream bufStream(*pool, &memStream, capacity, block, nullptr);
 
-    std::unique_ptr<BufferedOutputStream> outStream(
-        new BufferedOutputStream(*pool, &memStream, capacity, block, nullptr));
+    auto outStream =
+        std::make_unique<BufferedOutputStream>(*pool, &memStream, capacity, block, nullptr);
 
     std::unique_ptr<ByteRleEncoder> encoder = createBooleanRleEncoder(std::move(outStream));
 
@@ -175,8 +175,8 @@ namespace orc {
     uint64_t block = 1024;
     BufferedOutputStream bufStream(*pool, &memStream, capacity, block, nullptr);
 
-    std::unique_ptr<BufferedOutputStream> outStream(
-        new BufferedOutputStream(*pool, &memStream, capacity, block, nullptr));
+    auto outStream =
+        std::make_unique<BufferedOutputStream>(*pool, &memStream, capacity, block, nullptr);
 
     std::unique_ptr<ByteRleEncoder> encoder = createBooleanRleEncoder(std::move(outStream));
 
@@ -197,8 +197,8 @@ namespace orc {
     uint64_t block = 1024;
     BufferedOutputStream bufStream(*pool, &memStream, capacity, block, nullptr);
 
-    std::unique_ptr<BufferedOutputStream> outStream(
-        new BufferedOutputStream(*pool, &memStream, capacity, block, nullptr));
+    auto outStream =
+        std::make_unique<BufferedOutputStream>(*pool, &memStream, capacity, block, nullptr);
 
     std::unique_ptr<ByteRleEncoder> encoder = createBooleanRleEncoder(std::move(outStream));
 

--- a/c++/test/TestByteRle.cc
+++ b/c++/test/TestByteRle.cc
@@ -32,8 +32,7 @@ namespace orc {
   TEST(ByteRle, simpleTest) {
     const unsigned char buffer[] = {0x61, 0x00, 0xfd, 0x44, 0x45, 0x46};
     std::unique_ptr<ByteRleDecoder> rle =
-        createByteRleDecoder(std::unique_ptr<SeekableInputStream>(
-                                 new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer))),
+        createByteRleDecoder(std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer)),
                              getDefaultReaderMetrics());
     std::vector<char> data(103);
     rle->next(data.data(), data.size(), nullptr);
@@ -59,9 +58,9 @@ namespace orc {
     for (int i = 0; i < 266; ++i) {
       notNull[i] = static_cast<char>(i >= 10);
     }
-    std::unique_ptr<ByteRleDecoder> rle = createByteRleDecoder(
-        std::unique_ptr<SeekableInputStream>(new SeekableArrayInputStream(buffer, sizeof(buffer))),
-        getDefaultReaderMetrics());
+    std::unique_ptr<ByteRleDecoder> rle =
+        createByteRleDecoder(std::make_unique<SeekableArrayInputStream>(buffer, sizeof(buffer)),
+                             getDefaultReaderMetrics());
     rle->next(result, sizeof(result), notNull);
     for (size_t i = 0; i < sizeof(result); ++i) {
       if (i >= 10) {
@@ -73,10 +72,9 @@ namespace orc {
   TEST(ByteRle, literalCrossBuffer) {
     const unsigned char buffer[] = {0xf6, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05,
                                     0x06, 0x07, 0x08, 0x09, 0x07, 0x10};
-    std::unique_ptr<ByteRleDecoder> rle =
-        createByteRleDecoder(std::unique_ptr<SeekableInputStream>(
-                                 new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer), 6)),
-                             getDefaultReaderMetrics());
+    std::unique_ptr<ByteRleDecoder> rle = createByteRleDecoder(
+        std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer), 6),
+        getDefaultReaderMetrics());
     std::vector<char> data(20);
     rle->next(data.data(), data.size(), nullptr);
 
@@ -90,10 +88,9 @@ namespace orc {
 
   TEST(ByteRle, skipLiteralBufferUnderflowTest) {
     const unsigned char buffer[] = {0xf8, 0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7};
-    std::unique_ptr<ByteRleDecoder> rle =
-        createByteRleDecoder(std::unique_ptr<SeekableInputStream>(
-                                 new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer), 4)),
-                             getDefaultReaderMetrics());
+    std::unique_ptr<ByteRleDecoder> rle = createByteRleDecoder(
+        std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer), 4),
+        getDefaultReaderMetrics());
     std::vector<char> data(8);
     rle->next(data.data(), 3, nullptr);
     EXPECT_EQ(0x0, data[0]);
@@ -110,8 +107,7 @@ namespace orc {
   TEST(ByteRle, simpleRuns) {
     const unsigned char buffer[] = {0x0d, 0xff, 0x0d, 0xfe, 0x0d, 0xfd};
     std::unique_ptr<ByteRleDecoder> rle =
-        createByteRleDecoder(std::unique_ptr<SeekableInputStream>(
-                                 new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer))),
+        createByteRleDecoder(std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer)),
                              getDefaultReaderMetrics());
     std::vector<char> data(16);
     for (size_t i = 0; i < 3; ++i) {
@@ -128,10 +124,9 @@ namespace orc {
                                     0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
                                     0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
                                     0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20};
-    std::unique_ptr<ByteRleDecoder> rle =
-        createByteRleDecoder(std::unique_ptr<orc::SeekableInputStream>(
-                                 new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer), 1)),
-                             getDefaultReaderMetrics());
+    std::unique_ptr<ByteRleDecoder> rle = createByteRleDecoder(
+        std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer), 1),
+        getDefaultReaderMetrics());
     std::vector<char> data(35);
     rle->next(data.data(), data.size(), nullptr);
     for (size_t i = 0; i < 3; ++i) {
@@ -146,8 +141,7 @@ namespace orc {
     const unsigned char buffer[] = {0x0d, 0x02, 0xf0, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
                                     0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10};
     std::unique_ptr<ByteRleDecoder> rle =
-        createByteRleDecoder(std::unique_ptr<orc::SeekableInputStream>(
-                                 new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer))),
+        createByteRleDecoder(std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer)),
                              getDefaultReaderMetrics());
     std::vector<char> data(5);
     for (size_t i = 0; i < 3; ++i) {
@@ -176,10 +170,9 @@ namespace orc {
   TEST(ByteRle, testNulls) {
     const unsigned char buffer[] = {0xf0, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
                                     0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x3d, 0xdc};
-    std::unique_ptr<ByteRleDecoder> rle =
-        createByteRleDecoder(std::unique_ptr<orc::SeekableInputStream>(
-                                 new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer), 3)),
-                             getDefaultReaderMetrics());
+    std::unique_ptr<ByteRleDecoder> rle = createByteRleDecoder(
+        std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer), 3),
+        getDefaultReaderMetrics());
     std::vector<char> data(16, static_cast<char>(-1));
     std::vector<char> notNull(data.size());
     for (size_t i = 0; i < data.size(); ++i) {
@@ -209,8 +202,7 @@ namespace orc {
     const unsigned char buffer[] = {0xf0, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
                                     0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x3d, 0xdc};
     std::unique_ptr<ByteRleDecoder> rle =
-        createByteRleDecoder(std::unique_ptr<orc::SeekableInputStream>(
-                                 new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer))),
+        createByteRleDecoder(std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer)),
                              getDefaultReaderMetrics());
     std::vector<char> data(16, static_cast<char>(-1));
     std::vector<char> allNull(data.size(), 0);
@@ -326,9 +318,9 @@ namespace orc {
         0xec, 0xed, 0xee, 0xef, 0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8, 0xf9, 0xfa,
         0xfb, 0xfc, 0xfd, 0xfe, 0xff,
     };
-    SeekableInputStream* const stream = new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer));
-    std::unique_ptr<ByteRleDecoder> rle = createByteRleDecoder(
-        std::unique_ptr<orc::SeekableInputStream>(stream), getDefaultReaderMetrics());
+    std::unique_ptr<ByteRleDecoder> rle =
+        createByteRleDecoder(std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer)),
+                             getDefaultReaderMetrics());
     std::vector<char> data(1);
     for (size_t i = 0; i < 2048; i += 10) {
       rle->next(data.data(), data.size(), nullptr);
@@ -456,8 +448,7 @@ namespace orc {
         0xe3, 0xe4, 0xe5, 0xe6, 0xe7, 0xe8, 0xe9, 0xea, 0xeb, 0xec, 0xed, 0xee, 0xef, 0xf0, 0xf1,
         0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xff,
     };
-    std::unique_ptr<SeekableInputStream> stream(
-        new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer)));
+    auto stream = std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer));
     const uint64_t fileLocs[] = {
         0,    0,    0,    0,    0,    2,    2,    2,    2,    4,    4,    4,    4,    6,    6,
         6,    6,    8,    8,    8,    8,    10,   10,   10,   10,   12,   12,   12,   12,   14,
@@ -738,8 +729,7 @@ namespace orc {
   TEST(ByteRle, seekOverEmptyPresentStream) {
     const char* buffer = nullptr;
     std::unique_ptr<ByteRleDecoder> rle = createByteRleDecoder(
-        std::unique_ptr<orc::SeekableInputStream>(new SeekableArrayInputStream(buffer, 0, 1)),
-        getDefaultReaderMetrics());
+        std::make_unique<SeekableArrayInputStream>(buffer, 0, 1), getDefaultReaderMetrics());
     std::list<uint64_t> position(2, 0);
     PositionProvider location(position);
     rle->seek(location);
@@ -747,10 +737,9 @@ namespace orc {
 
   TEST(BooleanRle, simpleTest) {
     const unsigned char buffer[] = {0x61, 0xf0, 0xfd, 0x55, 0xAA, 0x55};
-    std::unique_ptr<SeekableInputStream> stream(
-        new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer)));
-    std::unique_ptr<ByteRleDecoder> rle =
-        createBooleanRleDecoder(std::move(stream), getDefaultReaderMetrics());
+    std::unique_ptr<ByteRleDecoder> rle = createBooleanRleDecoder(
+        std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer)),
+        getDefaultReaderMetrics());
     std::vector<char> data(50);
     for (size_t i = 0; i < 16; ++i) {
       rle->next(data.data(), data.size(), nullptr);
@@ -770,10 +759,9 @@ namespace orc {
 
   TEST(BooleanRle, runsTest) {
     const unsigned char buffer[] = {0xf7, 0xff, 0x80, 0x3f, 0xe0, 0x0f, 0xf8, 0x03, 0xfe, 0x00};
-    std::unique_ptr<SeekableInputStream> stream(
-        new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer)));
-    std::unique_ptr<ByteRleDecoder> rle =
-        createBooleanRleDecoder(std::move(stream), getDefaultReaderMetrics());
+    std::unique_ptr<ByteRleDecoder> rle = createBooleanRleDecoder(
+        std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer)),
+        getDefaultReaderMetrics());
     std::vector<char> data(72);
     rle->next(data.data(), data.size(), nullptr);
     for (size_t i = 0; i < data.size(); ++i) {
@@ -790,10 +778,9 @@ namespace orc {
 
   TEST(BooleanRle, runsTestWithNull) {
     const unsigned char buffer[] = {0xf7, 0xff, 0x80, 0x3f, 0xe0, 0x0f, 0xf8, 0x03, 0xfe, 0x00};
-    std::unique_ptr<SeekableInputStream> stream(
-        new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer)));
-    std::unique_ptr<ByteRleDecoder> rle =
-        createBooleanRleDecoder(std::move(stream), getDefaultReaderMetrics());
+    std::unique_ptr<ByteRleDecoder> rle = createBooleanRleDecoder(
+        std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer)),
+        getDefaultReaderMetrics());
     std::vector<char> data(72);
     std::vector<char> notNull(data.size(), 1);
     rle->next(data.data(), data.size(), notNull.data());
@@ -887,10 +874,9 @@ namespace orc {
         0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c,
         0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c,
         0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c, 0x71};
-    std::unique_ptr<SeekableInputStream> stream(
-        new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer)));
-    std::unique_ptr<ByteRleDecoder> rle =
-        createBooleanRleDecoder(std::move(stream), getDefaultReaderMetrics());
+    std::unique_ptr<ByteRleDecoder> rle = createBooleanRleDecoder(
+        std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer)),
+        getDefaultReaderMetrics());
     std::vector<char> data(1);
     for (size_t i = 0; i < 16384; i += 5) {
       rle->next(data.data(), data.size(), nullptr);
@@ -980,10 +966,9 @@ namespace orc {
         0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c,
         0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c,
         0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c, 0x71};
-    std::unique_ptr<SeekableInputStream> stream(
-        new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer)));
-    std::unique_ptr<ByteRleDecoder> rle =
-        createBooleanRleDecoder(std::move(stream), getDefaultReaderMetrics());
+    std::unique_ptr<ByteRleDecoder> rle = createBooleanRleDecoder(
+        std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer)),
+        getDefaultReaderMetrics());
     std::vector<char> data(3);
     std::vector<char> someNull(data.size(), 0);
     someNull[1] = 1;
@@ -1084,10 +1069,9 @@ namespace orc {
         0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c,
         0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c,
         0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c, 0x71};
-    std::unique_ptr<SeekableInputStream> stream(
-        new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer)));
-    std::unique_ptr<ByteRleDecoder> rle =
-        createBooleanRleDecoder(std::move(stream), getDefaultReaderMetrics());
+    std::unique_ptr<ByteRleDecoder> rle = createBooleanRleDecoder(
+        std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer)),
+        getDefaultReaderMetrics());
     std::vector<char> data(16384);
     rle->next(data.data(), data.size(), nullptr);
     for (size_t i = 0; i < data.size(); ++i) {
@@ -1194,10 +1178,9 @@ namespace orc {
         0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c,
         0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c,
         0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c, 0x71, 0xc7, 0x1c, 0x71};
-    std::unique_ptr<SeekableInputStream> stream(
-        new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer)));
-    std::unique_ptr<ByteRleDecoder> rle =
-        createBooleanRleDecoder(std::move(stream), getDefaultReaderMetrics());
+    std::unique_ptr<ByteRleDecoder> rle = createBooleanRleDecoder(
+        std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer)),
+        getDefaultReaderMetrics());
     std::vector<char> data(16384);
     std::vector<char> allNull(data.size(), 0);
     std::vector<char> noNull(data.size(), 1);
@@ -1249,10 +1232,9 @@ namespace orc {
                         0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 1, 1};
     const unsigned char buffer[] = {0xf9, 0xf0, 0xf0, 0xf7, 0x1c, 0x71, 0xc1, 0x80};
 
-    std::unique_ptr<SeekableInputStream> stream(
-        new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer)));
-    std::unique_ptr<ByteRleDecoder> rle =
-        createBooleanRleDecoder(std::move(stream), getDefaultReaderMetrics());
+    std::unique_ptr<ByteRleDecoder> rle = createBooleanRleDecoder(
+        std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer)),
+        getDefaultReaderMetrics());
     std::vector<char> data(sizeof(num) / sizeof(char));
     rle->next(data.data(), data.size(), nullptr);
     for (size_t i = 0; i < data.size(); ++i) {
@@ -1287,10 +1269,10 @@ namespace orc {
 
     // create BooleanRleDecoder and prepare decoding
     std::unique_ptr<ByteRleDecoder> decoder = createBooleanRleDecoder(
-        createDecompressor(CompressionKind_ZSTD,
-                           std::unique_ptr<SeekableInputStream>(new SeekableArrayInputStream(
-                               memStream.getData(), memStream.getLength())),
-                           blockSize, *getDefaultPool(), getDefaultReaderMetrics()),
+        createDecompressor(
+            CompressionKind_ZSTD,
+            std::make_unique<SeekableArrayInputStream>(memStream.getData(), memStream.getLength()),
+            blockSize, *getDefaultPool(), getDefaultReaderMetrics()),
         getDefaultReaderMetrics());
 
     // before fix of ORC-470, skip all remaining boolean values will get an
@@ -1308,8 +1290,8 @@ namespace orc {
 
     uint64_t capacity = 500 * 1024;
     uint64_t block = 1024;
-    std::unique_ptr<BufferedOutputStream> outStream(
-        new BufferedOutputStream(*getDefaultPool(), &memStream, capacity, block, nullptr));
+    auto outStream = std::make_unique<BufferedOutputStream>(*getDefaultPool(), &memStream, capacity,
+                                                            block, nullptr);
 
     std::unique_ptr<ByteRleEncoder> encoder = createBooleanRleEncoder(std::move(outStream));
 
@@ -1321,8 +1303,8 @@ namespace orc {
     encoder->add(data, numValues, nullptr);
     encoder->flush();
 
-    std::unique_ptr<SeekableInputStream> inStream(
-        new SeekableArrayInputStream(memStream.getData(), memStream.getLength()));
+    auto inStream =
+        std::make_unique<SeekableArrayInputStream>(memStream.getData(), memStream.getLength());
 
     std::unique_ptr<ByteRleDecoder> decoder =
         createBooleanRleDecoder(std::move(inStream), getDefaultReaderMetrics());

--- a/c++/test/TestColumnStatistics.cc
+++ b/c++/test/TestColumnStatistics.cc
@@ -26,7 +26,7 @@
 namespace orc {
 
   TEST(ColumnStatistics, intColumnStatistics) {
-    std::unique_ptr<IntegerColumnStatisticsImpl> intStats(new IntegerColumnStatisticsImpl());
+    auto intStats = std::make_unique<IntegerColumnStatisticsImpl>();
 
     // initial state
     EXPECT_EQ(0, intStats->getNumberOfValues());
@@ -69,7 +69,7 @@ namespace orc {
     EXPECT_EQ(51, intStats->getSum());
 
     // test merge
-    std::unique_ptr<IntegerColumnStatisticsImpl> other(new IntegerColumnStatisticsImpl());
+    auto other = std::make_unique<IntegerColumnStatisticsImpl>();
 
     other->setHasNull(true);
     other->increase(100);
@@ -105,7 +105,7 @@ namespace orc {
     intStats->merge(*other);
     EXPECT_FALSE(intStats->hasSum());
 
-    std::unique_ptr<IntegerColumnStatisticsImpl> intStats2(new IntegerColumnStatisticsImpl());
+    auto intStats2 = std::make_unique<IntegerColumnStatisticsImpl>();
 
     intStats2->update(1, 1);
     EXPECT_TRUE(intStats2->hasSum());
@@ -114,7 +114,7 @@ namespace orc {
   }
 
   TEST(ColumnStatistics, doubleColumnStatistics) {
-    std::unique_ptr<DoubleColumnStatisticsImpl> dblStats(new DoubleColumnStatisticsImpl());
+    auto dblStats = std::make_unique<DoubleColumnStatisticsImpl>();
 
     // initial state
     EXPECT_EQ(0, dblStats->getNumberOfValues());
@@ -156,7 +156,7 @@ namespace orc {
     EXPECT_TRUE(std::abs(-95454.5343 - dblStats->getMinimum()) < 0.00001);
 
     // test merge
-    std::unique_ptr<DoubleColumnStatisticsImpl> other(new DoubleColumnStatisticsImpl());
+    auto other = std::make_unique<DoubleColumnStatisticsImpl>();
 
     other->setHasNull(true);
     other->increase(987);
@@ -178,7 +178,7 @@ namespace orc {
   }
 
   TEST(ColumnStatistics, stringColumnStatistics) {
-    std::unique_ptr<StringColumnStatisticsImpl> strStats(new StringColumnStatisticsImpl());
+    auto strStats = std::make_unique<StringColumnStatisticsImpl>();
 
     EXPECT_FALSE(strStats->hasMinimum());
     EXPECT_FALSE(strStats->hasMaximum());
@@ -216,7 +216,7 @@ namespace orc {
   }
 
   TEST(ColumnStatistics, boolColumnStatistics) {
-    std::unique_ptr<BooleanColumnStatisticsImpl> boolStats(new BooleanColumnStatisticsImpl());
+    auto boolStats = std::make_unique<BooleanColumnStatisticsImpl>();
 
     // initial state
     EXPECT_EQ(0, boolStats->getNumberOfValues());
@@ -233,7 +233,7 @@ namespace orc {
     EXPECT_EQ(3, boolStats->getTrueCount());
 
     // test merge
-    std::unique_ptr<BooleanColumnStatisticsImpl> other(new BooleanColumnStatisticsImpl());
+    auto other = std::make_unique<BooleanColumnStatisticsImpl>();
 
     other->setHasNull(true);
     other->increase(100);
@@ -248,7 +248,7 @@ namespace orc {
   }
 
   TEST(ColumnStatistics, timestampColumnStatistics) {
-    std::unique_ptr<TimestampColumnStatisticsImpl> tsStats(new TimestampColumnStatisticsImpl());
+    auto tsStats = std::make_unique<TimestampColumnStatisticsImpl>();
 
     EXPECT_FALSE(tsStats->hasMaximum() || tsStats->hasMaximum());
 
@@ -266,7 +266,7 @@ namespace orc {
     EXPECT_EQ(999999, tsStats->getMaximumNanos());
 
     // test merge
-    std::unique_ptr<TimestampColumnStatisticsImpl> other(new TimestampColumnStatisticsImpl());
+    auto other = std::make_unique<TimestampColumnStatisticsImpl>();
 
     other->setMaximum(160);
     other->setMinimum(90);
@@ -279,7 +279,7 @@ namespace orc {
   }
 
   TEST(ColumnStatistics, dateColumnStatistics) {
-    std::unique_ptr<DateColumnStatisticsImpl> tsStats(new DateColumnStatisticsImpl());
+    auto tsStats = std::make_unique<DateColumnStatisticsImpl>();
 
     EXPECT_FALSE(tsStats->hasMaximum() || tsStats->hasMaximum());
 
@@ -293,7 +293,7 @@ namespace orc {
     EXPECT_EQ(100, tsStats->getMinimum());
 
     // test merge
-    std::unique_ptr<DateColumnStatisticsImpl> other(new DateColumnStatisticsImpl());
+    auto other = std::make_unique<DateColumnStatisticsImpl>();
 
     other->setMaximum(160);
     other->setMinimum(90);
@@ -304,7 +304,7 @@ namespace orc {
   }
 
   TEST(ColumnStatistics, otherColumnStatistics) {
-    std::unique_ptr<ColumnStatisticsImpl> stats(new ColumnStatisticsImpl());
+    auto stats = std::make_unique<ColumnStatisticsImpl>();
 
     EXPECT_EQ(0, stats->getNumberOfValues());
     EXPECT_FALSE(stats->hasNull());
@@ -320,7 +320,7 @@ namespace orc {
   }
 
   TEST(ColumnStatistics, decimalColumnStatistics) {
-    std::unique_ptr<DecimalColumnStatisticsImpl> decStats(new DecimalColumnStatisticsImpl());
+    auto decStats = std::make_unique<DecimalColumnStatisticsImpl>();
 
     // initial state
     EXPECT_EQ(0, decStats->getNumberOfValues());
@@ -386,7 +386,7 @@ namespace orc {
   }
 
   TEST(ColumnStatistics, timestampColumnStatisticsWithNanos) {
-    std::unique_ptr<TimestampColumnStatisticsImpl> tsStats(new TimestampColumnStatisticsImpl());
+    auto tsStats = std::make_unique<TimestampColumnStatisticsImpl>();
 
     // normal operations
     for (int32_t i = 1; i <= 1024; ++i) {
@@ -409,7 +409,7 @@ namespace orc {
     EXPECT_EQ(999, tsStats->getMinimumNanos());
 
     // test merge with no change
-    std::unique_ptr<TimestampColumnStatisticsImpl> other1(new TimestampColumnStatisticsImpl());
+    auto other1 = std::make_unique<TimestampColumnStatisticsImpl>();
     for (int32_t i = 1; i <= 1024; ++i) {
       other1->update(i * 100, i * 1000);
       other1->increase(1);
@@ -421,7 +421,7 @@ namespace orc {
     EXPECT_EQ(999, tsStats->getMinimumNanos());
 
     // test merge with min/max change only in nano
-    std::unique_ptr<TimestampColumnStatisticsImpl> other2(new TimestampColumnStatisticsImpl());
+    auto other2 = std::make_unique<TimestampColumnStatisticsImpl>();
     other2->update(102400, 1024002);
     other2->update(100, 998);
     tsStats->merge(*other2);
@@ -431,7 +431,7 @@ namespace orc {
     EXPECT_EQ(998, tsStats->getMinimumNanos());
 
     // test merge with min/max change in milli
-    std::unique_ptr<TimestampColumnStatisticsImpl> other3(new TimestampColumnStatisticsImpl());
+    auto other3 = std::make_unique<TimestampColumnStatisticsImpl>();
     other3->update(102401, 1);
     other3->update(99, 1);
     tsStats->merge(*other3);
@@ -442,7 +442,7 @@ namespace orc {
   }
 
   TEST(ColumnStatistics, timestampColumnStatisticsProbubuf) {
-    std::unique_ptr<TimestampColumnStatisticsImpl> tsStats(new TimestampColumnStatisticsImpl());
+    auto tsStats = std::make_unique<TimestampColumnStatisticsImpl>();
     tsStats->increase(2);
     tsStats->update(100);
     tsStats->update(200);
@@ -455,8 +455,7 @@ namespace orc {
     EXPECT_FALSE(pbStats.timestampstatistics().has_maximumnanos());
 
     StatContext ctx(true, nullptr);
-    std::unique_ptr<TimestampColumnStatisticsImpl> tsStatsFromPb(
-        new TimestampColumnStatisticsImpl(pbStats, ctx));
+    auto tsStatsFromPb = std::make_unique<TimestampColumnStatisticsImpl>(pbStats, ctx);
     EXPECT_EQ(100, tsStatsFromPb->getMinimum());
     EXPECT_EQ(200, tsStatsFromPb->getMaximum());
     EXPECT_EQ(0, tsStatsFromPb->getMinimumNanos());
@@ -481,8 +480,7 @@ namespace orc {
   }
 
   TEST(ColumnStatistics, collectionColumnStatistics) {
-    std::unique_ptr<CollectionColumnStatisticsImpl> collectionStats(
-        new CollectionColumnStatisticsImpl());
+    auto collectionStats = std::make_unique<CollectionColumnStatisticsImpl>();
 
     // initial state
     EXPECT_EQ(0, collectionStats->getNumberOfValues());
@@ -512,7 +510,7 @@ namespace orc {
 
     EXPECT_EQ(30, collectionStats->getTotalChildren());
     // test merge
-    std::unique_ptr<CollectionColumnStatisticsImpl> other(new CollectionColumnStatisticsImpl());
+    auto other = std::make_unique<CollectionColumnStatisticsImpl>();
 
     other->update(40);
     other->update(30);

--- a/c++/test/TestCompression.cc
+++ b/c++/test/TestCompression.cc
@@ -43,8 +43,8 @@ namespace orc {
 
   void decompressAndVerify(const MemoryOutputStream& memStream, CompressionKind kind,
                            const char* data, size_t size, MemoryPool& pool) {
-    std::unique_ptr<SeekableInputStream> inputStream(
-        new SeekableArrayInputStream(memStream.getData(), memStream.getLength()));
+    auto inputStream =
+        std::make_unique<SeekableArrayInputStream>(memStream.getData(), memStream.getLength());
 
     std::unique_ptr<SeekableInputStream> decompressStream =
         createDecompressor(kind, std::move(inputStream), 1024, pool, getDefaultReaderMetrics());
@@ -210,8 +210,8 @@ namespace orc {
     EXPECT_TRUE(ps.SerializeToZeroCopyStream(compressStream.get()));
     compressStream->flush();
 
-    std::unique_ptr<SeekableInputStream> inputStream(
-        new SeekableArrayInputStream(memStream.getData(), memStream.getLength()));
+    auto inputStream =
+        std::make_unique<SeekableArrayInputStream>(memStream.getData(), memStream.getLength());
 
     std::unique_ptr<SeekableInputStream> decompressStream =
         createDecompressor(kind, std::move(inputStream), 1024, *pool, getDefaultReaderMetrics());
@@ -332,8 +332,8 @@ namespace orc {
     outStream.flush();
 
     // try to decompress them
-    std::unique_ptr<SeekableInputStream> inputStream(
-        new SeekableArrayInputStream(memStream.getData(), memStream.getLength()));
+    auto inputStream =
+        std::make_unique<SeekableArrayInputStream>(memStream.getData(), memStream.getLength());
     std::unique_ptr<SeekableInputStream> decompressStream = createDecompressor(
         kind, std::move(inputStream), blockSize, *pool, getDefaultReaderMetrics());
 

--- a/c++/test/TestDecompression.cc
+++ b/c++/test/TestDecompression.cc
@@ -318,8 +318,7 @@ namespace orc {
     }
     std::unique_ptr<SeekableInputStream> result =
         createDecompressor(CompressionKind_NONE,
-                           std::unique_ptr<SeekableInputStream>(
-                               new SeekableArrayInputStream(bytes.data(), bytes.size())),
+                           std::make_unique<SeekableArrayInputStream>(bytes.data(), bytes.size()),
                            32768, *getDefaultPool(), getDefaultReaderMetrics());
     const void* ptr;
     int length;
@@ -332,8 +331,7 @@ namespace orc {
   TEST_F(TestDecompression, testLzoEmpty) {
     const unsigned char buffer[] = {0};
     std::unique_ptr<SeekableInputStream> result = createDecompressor(
-        CompressionKind_LZO,
-        std::unique_ptr<SeekableInputStream>(new SeekableArrayInputStream(buffer, 0)), 32768,
+        CompressionKind_LZO, std::make_unique<SeekableArrayInputStream>(buffer, 0), 32768,
         *getDefaultPool(), getDefaultReaderMetrics());
     EXPECT_EQ("lzo(SeekableArrayInputStream 0 of 0)", result->getName());
     const void* ptr;
@@ -345,11 +343,9 @@ namespace orc {
     const unsigned char buffer[] = {70,  0,   0,   48,  88,  88,  88, 88, 97, 98, 99, 100, 97,
                                     98,  99,  100, 65,  66,  67,  68, 65, 66, 67, 68, 119, 120,
                                     121, 122, 119, 122, 121, 122, 49, 50, 51, 17, 0,  0};
-    std::unique_ptr<SeekableInputStream> result =
-        createDecompressor(CompressionKind_LZO,
-                           std::unique_ptr<SeekableInputStream>(
-                               new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer))),
-                           128 * 1024, *getDefaultPool(), getDefaultReaderMetrics());
+    std::unique_ptr<SeekableInputStream> result = createDecompressor(
+        CompressionKind_LZO, std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer)),
+        128 * 1024, *getDefaultPool(), getDefaultReaderMetrics());
     const void* ptr;
     int length;
     ASSERT_EQ(true, result->Next(&ptr, &length));
@@ -386,11 +382,9 @@ namespace orc {
     buffer[458] = 2;
     memset(buffer + 459, 97, 20);
     buffer[479] = 17;
-    std::unique_ptr<SeekableInputStream> result =
-        createDecompressor(CompressionKind_LZO,
-                           std::unique_ptr<SeekableInputStream>(
-                               new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer))),
-                           128 * 1024, *getDefaultPool(), getDefaultReaderMetrics());
+    std::unique_ptr<SeekableInputStream> result = createDecompressor(
+        CompressionKind_LZO, std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer)),
+        128 * 1024, *getDefaultPool(), getDefaultReaderMetrics());
     const void* ptr;
     int length;
     ASSERT_EQ(true, result->Next(&ptr, &length));
@@ -404,8 +398,7 @@ namespace orc {
   TEST_F(TestDecompression, testLz4Empty) {
     const unsigned char buffer[] = {0};
     std::unique_ptr<SeekableInputStream> result = createDecompressor(
-        CompressionKind_LZ4,
-        std::unique_ptr<SeekableInputStream>(new SeekableArrayInputStream(buffer, 0)), 32768,
+        CompressionKind_LZ4, std::make_unique<SeekableArrayInputStream>(buffer, 0), 32768,
         *getDefaultPool(), getDefaultReaderMetrics());
     EXPECT_EQ("lz4(SeekableArrayInputStream 0 of 0)", result->getName());
     const void* ptr;
@@ -417,11 +410,9 @@ namespace orc {
     const unsigned char buffer[] = {60,  0,   0,   128, 88,  88,  88,  88,  97, 98, 99,
                                     100, 4,   0,   64,  65,  66,  67,  68,  4,  0,  176,
                                     119, 120, 121, 122, 119, 122, 121, 122, 49, 50, 51};
-    std::unique_ptr<SeekableInputStream> result =
-        createDecompressor(CompressionKind_LZ4,
-                           std::unique_ptr<SeekableInputStream>(
-                               new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer))),
-                           128 * 1024, *getDefaultPool(), getDefaultReaderMetrics());
+    std::unique_ptr<SeekableInputStream> result = createDecompressor(
+        CompressionKind_LZ4, std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer)),
+        128 * 1024, *getDefaultPool(), getDefaultReaderMetrics());
     const void* ptr;
     int length;
     ASSERT_EQ(true, result->Next(&ptr, &length));
@@ -451,11 +442,9 @@ namespace orc {
     buffer[400] = 80;
     memset(buffer + 401, 97, 5);
 
-    std::unique_ptr<SeekableInputStream> result =
-        createDecompressor(CompressionKind_LZ4,
-                           std::unique_ptr<SeekableInputStream>(
-                               new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer))),
-                           128 * 1024, *getDefaultPool(), getDefaultReaderMetrics());
+    std::unique_ptr<SeekableInputStream> result = createDecompressor(
+        CompressionKind_LZ4, std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer)),
+        128 * 1024, *getDefaultPool(), getDefaultReaderMetrics());
     const void* ptr;
     int length;
     ASSERT_EQ(true, result->Next(&ptr, &length));
@@ -470,8 +459,7 @@ namespace orc {
     const unsigned char buffer[] = {0x0b, 0x0, 0x0, 0x0, 0x1, 0x2, 0x3, 0x4};
     std::unique_ptr<SeekableInputStream> result =
         createDecompressor(CompressionKind_ZLIB,
-                           std::unique_ptr<SeekableInputStream>(
-                               new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer))),
+                           std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer)),
                            32768, *getDefaultPool(), getDefaultReaderMetrics());
     EXPECT_EQ("zlib(SeekableArrayInputStream 0 of 8)", result->getName());
     const void* ptr;
@@ -495,11 +483,10 @@ namespace orc {
   TEST(Zlib, testLiteralBlocks) {
     const unsigned char buffer[] = {0x19, 0x0, 0x0, 0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8,
                                     0x9,  0xa, 0xb, 0xb, 0x0, 0x0, 0xc, 0xd, 0xe, 0xf, 0x10};
-    std::unique_ptr<SeekableInputStream> result =
-        createDecompressor(CompressionKind_ZLIB,
-                           std::unique_ptr<SeekableInputStream>(
-                               new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer), 5)),
-                           5, *getDefaultPool(), getDefaultReaderMetrics());
+    std::unique_ptr<SeekableInputStream> result = createDecompressor(
+        CompressionKind_ZLIB,
+        std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer), 5), 5,
+        *getDefaultPool(), getDefaultReaderMetrics());
     EXPECT_EQ("zlib(SeekableArrayInputStream 0 of 23)", result->getName());
     const void* ptr;
     int length;
@@ -536,8 +523,7 @@ namespace orc {
     const unsigned char buffer[] = {0xe, 0x0, 0x0, 0x63, 0x60, 0x64, 0x62, 0xc0, 0x8d, 0x0};
     std::unique_ptr<SeekableInputStream> result =
         createDecompressor(CompressionKind_ZLIB,
-                           std::unique_ptr<SeekableInputStream>(
-                               new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer))),
+                           std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer)),
                            1000, *getDefaultPool(), getDefaultReaderMetrics());
     const void* ptr;
     int length;
@@ -553,11 +539,10 @@ namespace orc {
   TEST(Zlib, testInflateSequence) {
     const unsigned char buffer[] = {0xe, 0x0, 0x0, 0x63, 0x60, 0x64, 0x62, 0xc0, 0x8d, 0x0,
                                     0xe, 0x0, 0x0, 0x63, 0x60, 0x64, 0x62, 0xc0, 0x8d, 0x0};
-    std::unique_ptr<SeekableInputStream> result =
-        createDecompressor(CompressionKind_ZLIB,
-                           std::unique_ptr<SeekableInputStream>(
-                               new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer), 3)),
-                           1000, *getDefaultPool(), getDefaultReaderMetrics());
+    std::unique_ptr<SeekableInputStream> result = createDecompressor(
+        CompressionKind_ZLIB,
+        std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer), 3), 1000,
+        *getDefaultPool(), getDefaultReaderMetrics());
     const void* ptr;
     int length;
     ASSERT_THROW(result->BackUp(20), std::logic_error);
@@ -587,11 +572,10 @@ namespace orc {
   TEST(Zlib, testSkip) {
     const unsigned char buffer[] = {0x19, 0x0, 0x0, 0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8,
                                     0x9,  0xa, 0xb, 0xb, 0x0, 0x0, 0xc, 0xd, 0xe, 0xf, 0x10};
-    std::unique_ptr<SeekableInputStream> result =
-        createDecompressor(CompressionKind_ZLIB,
-                           std::unique_ptr<SeekableInputStream>(
-                               new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer), 5)),
-                           5, *getDefaultPool(), getDefaultReaderMetrics());
+    std::unique_ptr<SeekableInputStream> result = createDecompressor(
+        CompressionKind_ZLIB,
+        std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer), 5), 5,
+        *getDefaultPool(), getDefaultReaderMetrics());
     const void* ptr;
     int length;
     ASSERT_EQ(true, result->Next(&ptr, &length));
@@ -669,8 +653,8 @@ namespace orc {
     const long blockSize = 3;
     std::unique_ptr<SeekableInputStream> result = createDecompressor(
         CompressionKind_SNAPPY,
-        std::unique_ptr<SeekableInputStream>(new SeekableArrayInputStream(
-            compressBuffer.getBuffer(), compressBuffer.getBufferSize(), blockSize)),
+        std::make_unique<SeekableArrayInputStream>(compressBuffer.getBuffer(),
+                                                   compressBuffer.getBufferSize(), blockSize),
         buf.size(), *getDefaultPool(), getDefaultReaderMetrics());
     const void* data;
     int length;
@@ -705,11 +689,10 @@ namespace orc {
              compressBuffer.getBufferSize());
 
     const long blockSize = 3;
-    std::unique_ptr<SeekableInputStream> result =
-        createDecompressor(CompressionKind_SNAPPY,
-                           std::unique_ptr<SeekableInputStream>(
-                               new SeekableArrayInputStream(input.data(), input.size(), blockSize)),
-                           buf.size(), *getDefaultPool(), getDefaultReaderMetrics());
+    std::unique_ptr<SeekableInputStream> result = createDecompressor(
+        CompressionKind_SNAPPY,
+        std::make_unique<SeekableArrayInputStream>(input.data(), input.size(), blockSize),
+        buf.size(), *getDefaultPool(), getDefaultReaderMetrics());
     for (int i = 0; i < 4; ++i) {
       const void* data;
       int length;
@@ -737,8 +720,8 @@ namespace orc {
     const long blockSize = 3;
     std::unique_ptr<SeekableInputStream> result = createDecompressor(
         CompressionKind_SNAPPY,
-        std::unique_ptr<SeekableInputStream>(new SeekableArrayInputStream(
-            compressBuffer.getBuffer(), compressBuffer.getBufferSize(), blockSize)),
+        std::make_unique<SeekableArrayInputStream>(compressBuffer.getBuffer(),
+                                                   compressBuffer.getBufferSize(), blockSize),
         buf.size(), *getDefaultPool(), getDefaultReaderMetrics());
     const void* data;
     int length;
@@ -767,8 +750,7 @@ namespace orc {
 
     // Choose a block size larger than the chunk size.
     const long blockSize = 300;
-    std::unique_ptr<SeekableInputStream> input(
-        new SeekableArrayInputStream(buf.data(), buf.size(), blockSize));
+    auto input = std::make_unique<SeekableArrayInputStream>(buf.data(), buf.size(), blockSize);
     std::unique_ptr<SeekableInputStream> stream =
         createDecompressor(CompressionKind_SNAPPY, std::move(input), chunkSize, *getDefaultPool(),
                            getDefaultReaderMetrics());

--- a/c++/test/TestPredicatePushdown.cc
+++ b/c++/test/TestPredicatePushdown.cc
@@ -310,8 +310,7 @@ namespace orc {
     MemoryOutputStream memStream(DEFAULT_MEM_STREAM_SIZE);
     MemoryPool* pool = getDefaultPool();
     createMemTestFile(memStream, 1000);
-    std::unique_ptr<InputStream> inStream(
-        new MemoryInputStream(memStream.getData(), memStream.getLength()));
+    auto inStream = std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
     ReaderOptions readerOptions;
     readerOptions.setMemoryPool(*pool);
     std::unique_ptr<Reader> reader = createReader(std::move(inStream), readerOptions);
@@ -372,8 +371,7 @@ namespace orc {
     MemoryPool* pool = getDefaultPool();
     // Create the file with rowIndexStride=0, so there are no row groups or row indexes.
     createMemTestFile(memStream, 0);
-    std::unique_ptr<InputStream> inStream(
-        new MemoryInputStream(memStream.getData(), memStream.getLength()));
+    auto inStream = std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
     ReaderOptions readerOptions;
     readerOptions.setMemoryPool(*pool);
     std::unique_ptr<Reader> reader = createReader(std::move(inStream), readerOptions);
@@ -533,8 +531,7 @@ namespace orc {
       writer->add(*batch);
     }
     writer->close();
-    std::unique_ptr<InputStream> inStream(
-        new MemoryInputStream(memStream.getData(), memStream.getLength()));
+    auto inStream = std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
     ReaderOptions readerOptions;
     readerOptions.setMemoryPool(*pool);
     std::unique_ptr<Reader> reader = createReader(std::move(inStream), readerOptions);

--- a/c++/test/TestReader.cc
+++ b/c++/test/TestReader.cc
@@ -214,8 +214,7 @@ namespace orc {
     writer->add(*batch);
     writer->close();
 
-    std::unique_ptr<InputStream> inStream(
-        new MemoryInputStream(memStream.getData(), memStream.getLength()));
+    auto inStream = std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
     ReaderOptions readerOptions;
     readerOptions.setMemoryPool(*pool);
     return createReader(std::move(inStream), readerOptions);
@@ -385,8 +384,7 @@ namespace orc {
     writer->add(*batch);
     writer->close();
 
-    std::unique_ptr<InputStream> inStream(
-        new MemoryInputStream(memStream.getData(), memStream.getLength()));
+    auto inStream = std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
     ReaderOptions readerOptions;
     readerOptions.setMemoryPool(*pool);
     return createReader(std::move(inStream), readerOptions);
@@ -561,8 +559,7 @@ namespace orc {
     writer->add(*batch);
     writer->close();
 
-    std::unique_ptr<InputStream> inStream(
-        new MemoryInputStream(memStream.getData(), memStream.getLength()));
+    auto inStream = std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
     ReaderOptions readerOptions;
     readerOptions.setMemoryPool(*pool);
     readerOptions.setReaderMetrics(nullptr);
@@ -732,8 +729,8 @@ namespace orc {
       writer->close();
     }
     {
-      std::unique_ptr<InputStream> inStream(
-          new MemoryInputStream(memStream.getData(), memStream.getLength()));
+      auto inStream =
+          std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
       ReaderOptions readerOptions;
       readerOptions.setMemoryPool(*pool);
       std::unique_ptr<Reader> reader = createReader(std::move(inStream), readerOptions);

--- a/c++/test/TestRleDecoder.cc
+++ b/c++/test/TestRleDecoder.cc
@@ -30,9 +30,9 @@ namespace orc {
   std::vector<int64_t> decodeRLEv2(const unsigned char* bytes, unsigned long l, size_t n,
                                    size_t count, const char* notNull = nullptr,
                                    bool isSigned = true, uint64_t blockSize = 0) {
-    std::unique_ptr<RleDecoder> rle = createRleDecoder(
-        std::unique_ptr<SeekableInputStream>(new SeekableArrayInputStream(bytes, l, blockSize)),
-        isSigned, RleVersion_2, *getDefaultPool(), getDefaultReaderMetrics());
+    std::unique_ptr<RleDecoder> rle =
+        createRleDecoder(std::make_unique<SeekableArrayInputStream>(bytes, l, blockSize), isSigned,
+                         RleVersion_2, *getDefaultPool(), getDefaultReaderMetrics());
     std::vector<int64_t> results;
     for (size_t i = 0; i < count; i += n) {
       size_t remaining = count - i;
@@ -166,8 +166,7 @@ namespace orc {
   TEST(RLEv2, delta0Width) {
     const unsigned char buffer[] = {0x4e, 0x2, 0x0, 0x1, 0x2, 0xc0, 0x2, 0x42, 0x0};
     std::unique_ptr<RleDecoder> decoder =
-        createRleDecoder(std::unique_ptr<SeekableInputStream>(
-                             new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer))),
+        createRleDecoder(std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer)),
                          false, RleVersion_2, *getDefaultPool(), getDefaultReaderMetrics());
     int64_t values[6];
     decoder->next(values, 6, 0);
@@ -250,8 +249,7 @@ namespace orc {
   TEST(RLEv2, 0to2Repeat1Direct) {
     const unsigned char buffer[] = {0x46, 0x02, 0x02, 0x40};
     std::unique_ptr<RleDecoder> rle =
-        createRleDecoder(std::unique_ptr<SeekableInputStream>(
-                             new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer))),
+        createRleDecoder(std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer)),
                          true, RleVersion_2, *getDefaultPool(), getDefaultReaderMetrics());
     std::vector<int64_t> data(3);
     rle->next(data.data(), 3, nullptr);
@@ -588,8 +586,7 @@ namespace orc {
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x99, 0xa5, 0xcc, 0x28, 0x03, 0xf7, 0xe0, 0xff};
     std::unique_ptr<RleDecoder> rle =
-        createRleDecoder(std::unique_ptr<SeekableInputStream>(
-                             new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer))),
+        createRleDecoder(std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer)),
                          true, RleVersion_2, *getDefaultPool(), getDefaultReaderMetrics());
     std::vector<int64_t> data(5);
     rle->next(data.data(), 5, nullptr);
@@ -724,9 +721,9 @@ namespace orc {
                                    0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04};
     unsigned long l = sizeof(bytes) / sizeof(char);
 
-    std::unique_ptr<RleDecoder> rle = createRleDecoder(
-        std::unique_ptr<SeekableInputStream>(new SeekableArrayInputStream(bytes, l)), true,
-        RleVersion_2, *getDefaultPool(), getDefaultReaderMetrics());
+    std::unique_ptr<RleDecoder> rle =
+        createRleDecoder(std::make_unique<SeekableArrayInputStream>(bytes, l), true, RleVersion_2,
+                         *getDefaultPool(), getDefaultReaderMetrics());
     std::list<uint64_t> position;
     position.push_back(7);   // byte position; skip first 20 [0 to 19]
     position.push_back(13);  // value position; skip 13 more [20 to 32]
@@ -786,9 +783,9 @@ namespace orc {
                 3,   13,  1,  92, 3,   13, 5,  14,  9,    141,   12,  6,   15, 25};
     unsigned long D = 118, P = sizeof(v) / sizeof(long), N = D + P;
 
-    std::unique_ptr<RleDecoder> rle = createRleDecoder(
-        std::unique_ptr<SeekableInputStream>(new SeekableArrayInputStream(bytes, l)), true,
-        RleVersion_2, *getDefaultPool(), getDefaultReaderMetrics());
+    std::unique_ptr<RleDecoder> rle =
+        createRleDecoder(std::make_unique<SeekableArrayInputStream>(bytes, l), true, RleVersion_2,
+                         *getDefaultPool(), getDefaultReaderMetrics());
 
     std::vector<int64_t> data(N);
     rle->next(data.data(), N, nullptr);
@@ -801,8 +798,7 @@ namespace orc {
   TEST(RLEv1, simpleTest) {
     const unsigned char buffer[] = {0x61, 0xff, 0x64, 0xfb, 0x02, 0x03, 0x5, 0x7, 0xb};
     std::unique_ptr<RleDecoder> rle =
-        createRleDecoder(std::unique_ptr<SeekableInputStream>(
-                             new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer))),
+        createRleDecoder(std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer)),
                          false, RleVersion_1, *getDefaultPool(), getDefaultReaderMetrics());
     std::vector<int64_t> data(105);
     rle->next(data.data(), 105, nullptr);
@@ -820,8 +816,7 @@ namespace orc {
   TEST(RLEv1, signedNullLiteralTest) {
     const unsigned char buffer[] = {0xf8, 0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7};
     std::unique_ptr<RleDecoder> rle =
-        createRleDecoder(std::unique_ptr<SeekableInputStream>(
-                             new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer))),
+        createRleDecoder(std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer)),
                          true, RleVersion_1, *getDefaultPool(), getDefaultReaderMetrics());
     std::vector<int64_t> data(8);
     std::vector<char> notNull(8, 1);
@@ -835,8 +830,7 @@ namespace orc {
   TEST(RLEv1, splitHeader) {
     const unsigned char buffer[] = {0x0, 0x00, 0xdc, 0xba, 0x98, 0x76};
     std::unique_ptr<RleDecoder> rle =
-        createRleDecoder(std::unique_ptr<SeekableInputStream>(
-                             new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer), 4)),
+        createRleDecoder(std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer), 4),
                          false, RleVersion_1, *getDefaultPool(), getDefaultReaderMetrics());
     std::vector<int64_t> data(200);
     rle->next(data.data(), 3, nullptr);
@@ -848,10 +842,9 @@ namespace orc {
 
   TEST(RLEv1, splitRuns) {
     const unsigned char buffer[] = {0x7d, 0x01, 0xff, 0x01, 0xfb, 0x01, 0x02, 0x03, 0x04, 0x05};
-    SeekableInputStream* const stream = new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer));
     std::unique_ptr<RleDecoder> rle =
-        createRleDecoder(std::unique_ptr<SeekableInputStream>(stream), false, RleVersion_1,
-                         *getDefaultPool(), getDefaultReaderMetrics());
+        createRleDecoder(std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer)),
+                         false, RleVersion_1, *getDefaultPool(), getDefaultReaderMetrics());
     std::vector<int64_t> data(200);
     for (size_t i = 0; i < 42; ++i) {
       rle->next(data.data(), 3, nullptr);
@@ -873,10 +866,9 @@ namespace orc {
 
   TEST(RLEv1, testSigned) {
     const unsigned char buffer[] = {0x7f, 0xff, 0x20};
-    SeekableInputStream* const stream = new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer));
     std::unique_ptr<RleDecoder> rle =
-        createRleDecoder(std::unique_ptr<SeekableInputStream>(stream), true, RleVersion_1,
-                         *getDefaultPool(), getDefaultReaderMetrics());
+        createRleDecoder(std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer)),
+                         true, RleVersion_1, *getDefaultPool(), getDefaultReaderMetrics());
     std::vector<int64_t> data(100);
     rle->next(data.data(), data.size(), nullptr);
     for (size_t i = 0; i < data.size(); ++i) {
@@ -890,10 +882,9 @@ namespace orc {
 
   TEST(RLEv1, testNull) {
     const unsigned char buffer[] = {0x75, 0x02, 0x00};
-    SeekableInputStream* const stream = new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer));
     std::unique_ptr<RleDecoder> rle =
-        createRleDecoder(std::unique_ptr<SeekableInputStream>(stream), true, RleVersion_1,
-                         *getDefaultPool(), getDefaultReaderMetrics());
+        createRleDecoder(std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer)),
+                         true, RleVersion_1, *getDefaultPool(), getDefaultReaderMetrics());
     std::vector<int64_t> data(24);
     std::vector<char> notNull(24);
     for (size_t i = 0; i < notNull.size(); ++i) {
@@ -917,10 +908,9 @@ namespace orc {
   TEST(RLEv1, testAllNulls) {
     const unsigned char buffer[] = {0xf0, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
                                     0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x3d, 0x00, 0x12};
-    SeekableInputStream* const stream = new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer));
     std::unique_ptr<RleDecoder> rle =
-        createRleDecoder(std::unique_ptr<SeekableInputStream>(stream), false, RleVersion_1,
-                         *getDefaultPool(), getDefaultReaderMetrics());
+        createRleDecoder(std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer)),
+                         false, RleVersion_1, *getDefaultPool(), getDefaultReaderMetrics());
     std::vector<int64_t> data(16, -1);
     std::vector<char> allNull(16, 0);
     std::vector<char> noNull(16, 1);
@@ -1128,10 +1118,9 @@ namespace orc {
         128, 188, 63,  128, 192, 63,  128, 196, 63,  128, 200, 63,  128, 204, 63,  128, 208, 63,
         128, 212, 63,  128, 216, 63,  128, 220, 63,  128, 224, 63,  128, 228, 63,  128, 232, 63,
         128, 236, 63,  128, 240, 63,  128, 244, 63,  128, 248, 63,  128, 252, 63};
-    SeekableInputStream* const stream = new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer));
     std::unique_ptr<RleDecoder> rle =
-        createRleDecoder(std::unique_ptr<SeekableInputStream>(stream), true, RleVersion_1,
-                         *getDefaultPool(), getDefaultReaderMetrics());
+        createRleDecoder(std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer)),
+                         true, RleVersion_1, *getDefaultPool(), getDefaultReaderMetrics());
     std::vector<int64_t> data(1);
     for (size_t i = 0; i < 2048; i += 10) {
       rle->next(data.data(), 1, nullptr);
@@ -1777,7 +1766,6 @@ namespace orc {
         151, 12,  193, 190, 224, 143, 9,   129, 245, 133, 204, 8,   182, 209, 250, 178, 8,   148,
         139, 144, 193, 11,  230, 182, 245, 164, 7,   149, 204, 161, 226, 14,  175, 229, 148, 166,
         13,  148, 140, 189, 216, 3};
-    SeekableInputStream* const stream = new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer));
     const long junk[] = {
         -1192035722, 1672896916,  1491444859,  -1244121273, -791680696,  1681943525,  -571055948,
         -1744759283, -998345856,  240559198,   1110691737,  -1078127818, 1478213963,  -1999074977,
@@ -2624,8 +2612,8 @@ namespace orc {
       positions[i].push_back(rleLoc[i]);
     }
     std::unique_ptr<RleDecoder> rle =
-        createRleDecoder(std::unique_ptr<SeekableInputStream>(stream), true, RleVersion_1,
-                         *getDefaultPool(), getDefaultReaderMetrics());
+        createRleDecoder(std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer)),
+                         true, RleVersion_1, *getDefaultPool(), getDefaultReaderMetrics());
     std::vector<int64_t> data(2048);
     rle->next(data.data(), data.size(), nullptr);
     for (size_t i = 0; i < data.size(); ++i) {
@@ -2658,8 +2646,7 @@ namespace orc {
   TEST(RLEv1, testLeadingNulls) {
     const unsigned char buffer[] = {0xfb, 0x01, 0x02, 0x03, 0x04, 0x05};
     std::unique_ptr<RleDecoder> rle =
-        createRleDecoder(std::unique_ptr<SeekableInputStream>(
-                             new SeekableArrayInputStream(buffer, ARRAY_SIZE(buffer))),
+        createRleDecoder(std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer)),
                          false, RleVersion_1, *getDefaultPool(), getDefaultReaderMetrics());
     std::vector<int64_t> data(10);
     const char isNull[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0x01, 0x01, 0x01};
@@ -2672,9 +2659,9 @@ namespace orc {
 
   TEST(RLEv1, seekOverEmptyPresentStream) {
     const char* buffer = nullptr;
-    std::unique_ptr<RleDecoder> rle = createRleDecoder(
-        std::unique_ptr<SeekableInputStream>(new SeekableArrayInputStream(buffer, 0, 1)), false,
-        RleVersion_1, *getDefaultPool(), getDefaultReaderMetrics());
+    std::unique_ptr<RleDecoder> rle =
+        createRleDecoder(std::make_unique<SeekableArrayInputStream>(buffer, 0, 1), false,
+                         RleVersion_1, *getDefaultPool(), getDefaultReaderMetrics());
     std::list<uint64_t> position(2, 0);
     PositionProvider location(position);
     rle->seek(location);

--- a/c++/test/TestRleEncoder.cc
+++ b/c++/test/TestRleEncoder.cc
@@ -80,10 +80,9 @@ namespace orc {
 
   void decodeAndVerify(RleVersion version, const MemoryOutputStream& memStream, int64_t* data,
                        uint64_t numValues, const char* notNull, bool isSinged) {
-    std::unique_ptr<RleDecoder> decoder =
-        createRleDecoder(std::unique_ptr<SeekableArrayInputStream>(new SeekableArrayInputStream(
-                             memStream.getData(), memStream.getLength())),
-                         isSinged, version, *getDefaultPool(), getDefaultReaderMetrics());
+    std::unique_ptr<RleDecoder> decoder = createRleDecoder(
+        std::make_unique<SeekableArrayInputStream>(memStream.getData(), memStream.getLength()),
+        isSinged, version, *getDefaultPool(), getDefaultReaderMetrics());
 
     int64_t* decodedData = new int64_t[numValues];
     decoder->next(decodedData, numValues, notNull);
@@ -101,9 +100,9 @@ namespace orc {
                                                   bool isSigned) {
     MemoryPool* pool = getDefaultPool();
 
-    return createRleEncoder(std::unique_ptr<BufferedOutputStream>(new BufferedOutputStream(
-                                *pool, &memStream, 500 * 1024, 1024, nullptr)),
-                            isSigned, version, *pool, alignBitpacking);
+    return createRleEncoder(
+        std::make_unique<BufferedOutputStream>(*pool, &memStream, 500 * 1024, 1024, nullptr),
+        isSigned, version, *pool, alignBitpacking);
   }
 
   void RleTest::runExampleTest(int64_t* inputData, uint64_t inputLength,

--- a/c++/test/TestTimestampStatistics.cc
+++ b/c++/test/TestTimestampStatistics.cc
@@ -94,8 +94,7 @@ namespace orc {
     writer->add(*batch);
     writer->close();
 
-    std::unique_ptr<InputStream> inStream(
-        new MemoryInputStream(memStream.getData(), memStream.getLength()));
+    auto inStream = std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
     ReaderOptions rOptions;
     rOptions.setMemoryPool(*pool);
     std::unique_ptr<Reader> reader = createReader(std::move(inStream), rOptions);
@@ -139,8 +138,7 @@ namespace orc {
     writer->add(*batch);
     writer->close();
 
-    std::unique_ptr<InputStream> inStream(
-        new MemoryInputStream(memStream.getData(), memStream.getLength()));
+    auto inStream = std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
     ReaderOptions rOptions;
     rOptions.setMemoryPool(*pool);
     std::unique_ptr<Reader> reader = createReader(std::move(inStream), rOptions);

--- a/c++/test/TestWriter.cc
+++ b/c++/test/TestWriter.cc
@@ -104,8 +104,7 @@ namespace orc {
                      &memStream, fileVersion);
     writer->close();
 
-    std::unique_ptr<InputStream> inStream(
-        new MemoryInputStream(memStream.getData(), memStream.getLength()));
+    auto inStream = std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
     std::unique_ptr<Reader> reader = createReader(pool, std::move(inStream));
     std::unique_ptr<RowReader> rowReader = createRowReader(reader.get());
     EXPECT_EQ(fileVersion, reader->getFormatVersion());
@@ -154,8 +153,7 @@ namespace orc {
     writer->addUserMetadata("name1", "value1");
     writer->close();
 
-    std::unique_ptr<InputStream> inStream(
-        new MemoryInputStream(memStream.getData(), memStream.getLength()));
+    auto inStream = std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
     std::unique_ptr<Reader> reader = createReader(pool, std::move(inStream));
     std::unique_ptr<RowReader> rowReader = createRowReader(reader.get());
     EXPECT_EQ(2000, reader->getNumberOfRows());
@@ -208,8 +206,7 @@ namespace orc {
 
     writer->close();
 
-    std::unique_ptr<InputStream> inStream(
-        new MemoryInputStream(memStream.getData(), memStream.getLength()));
+    auto inStream = std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
     std::unique_ptr<Reader> reader = createReader(pool, std::move(inStream));
     std::unique_ptr<RowReader> rowReader = createRowReader(reader.get());
     EXPECT_EQ(655350, reader->getNumberOfRows());
@@ -265,8 +262,7 @@ namespace orc {
     writer->add(*batch);
     writer->close();
 
-    std::unique_ptr<InputStream> inStream(
-        new MemoryInputStream(memStream.getData(), memStream.getLength()));
+    auto inStream = std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
     std::unique_ptr<Reader> reader = createReader(pool, std::move(inStream));
     std::unique_ptr<RowReader> rowReader = createRowReader(reader.get());
     EXPECT_EQ(65535, reader->getNumberOfRows());
@@ -322,8 +318,7 @@ namespace orc {
     writer->add(*batch);
     writer->close();
 
-    std::unique_ptr<InputStream> inStream(
-        new MemoryInputStream(memStream.getData(), memStream.getLength()));
+    auto inStream = std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
     std::unique_ptr<Reader> reader = createReader(pool, std::move(inStream));
     std::unique_ptr<RowReader> rowReader = createRowReader(reader.get());
     EXPECT_EQ(rowCount, reader->getNumberOfRows());
@@ -375,8 +370,7 @@ namespace orc {
     writer->add(*batch);
     writer->close();
 
-    std::unique_ptr<InputStream> inStream(
-        new MemoryInputStream(memStream.getData(), memStream.getLength()));
+    auto inStream = std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
     std::unique_ptr<Reader> reader = createReader(pool, std::move(inStream));
     std::unique_ptr<RowReader> rowReader = createRowReader(reader.get());
     EXPECT_EQ(rowCount, reader->getNumberOfRows());
@@ -420,8 +414,7 @@ namespace orc {
     writer->add(*batch);
     writer->close();
 
-    std::unique_ptr<InputStream> inStream(
-        new MemoryInputStream(memStream.getData(), memStream.getLength()));
+    auto inStream = std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
     std::unique_ptr<Reader> reader = createReader(pool, std::move(inStream));
     std::unique_ptr<RowReader> rowReader = createRowReader(reader.get());
     EXPECT_EQ(rowCount, reader->getNumberOfRows());
@@ -461,8 +454,7 @@ namespace orc {
     writer->add(*batch);
     writer->close();
 
-    std::unique_ptr<InputStream> inStream(
-        new MemoryInputStream(memStream.getData(), memStream.getLength()));
+    auto inStream = std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
     std::unique_ptr<Reader> reader = createReader(pool, std::move(inStream));
     std::unique_ptr<RowReader> rowReader = createRowReader(reader.get());
     EXPECT_EQ(rowCount, reader->getNumberOfRows());
@@ -503,8 +495,7 @@ namespace orc {
     writer->add(*batch);
     writer->close();
 
-    std::unique_ptr<InputStream> inStream(
-        new MemoryInputStream(memStream.getData(), memStream.getLength()));
+    auto inStream = std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
     std::unique_ptr<Reader> reader = createReader(pool, std::move(inStream));
     std::unique_ptr<RowReader> rowReader = createRowReader(reader.get());
     EXPECT_EQ(rowCount, reader->getNumberOfRows());
@@ -548,8 +539,7 @@ namespace orc {
     writer->add(*batch);
     writer->close();
 
-    std::unique_ptr<InputStream> inStream(
-        new MemoryInputStream(memStream.getData(), memStream.getLength()));
+    auto inStream = std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
     std::unique_ptr<Reader> reader = createReader(pool, std::move(inStream));
     std::unique_ptr<RowReader> rowReader = createRowReader(reader.get());
     EXPECT_EQ(rowCount, reader->getNumberOfRows());
@@ -594,8 +584,7 @@ namespace orc {
     writer->add(*batch);
     writer->close();
 
-    std::unique_ptr<InputStream> inStream(
-        new MemoryInputStream(memStream.getData(), memStream.getLength()));
+    auto inStream = std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
     auto reader = createReader(pool, std::move(inStream));
     auto rowReader = createRowReader(reader.get());
     batch = rowReader->createRowBatch(batchCount);
@@ -664,8 +653,7 @@ namespace orc {
     writer->close();
 
     // read timestamp from the reader timezone
-    std::unique_ptr<InputStream> inStream(
-        new MemoryInputStream(memStream.getData(), memStream.getLength()));
+    auto inStream = std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
     std::unique_ptr<Reader> reader = createReader(pool, std::move(inStream));
     std::unique_ptr<RowReader> rowReader = createRowReader(reader.get(), readerTimezone);
     EXPECT_EQ(true, rowReader->next(*batch));
@@ -758,8 +746,7 @@ namespace orc {
     writer->add(*batch);
     writer->close();
 
-    std::unique_ptr<InputStream> inStream(
-        new MemoryInputStream(memStream.getData(), memStream.getLength()));
+    auto inStream = std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
     std::unique_ptr<Reader> reader = createReader(pool, std::move(inStream));
     std::unique_ptr<RowReader> rowReader = createRowReader(reader.get());
     EXPECT_EQ(rowCount, reader->getNumberOfRows());
@@ -816,8 +803,7 @@ namespace orc {
     writer->add(*batch);
     writer->close();
 
-    std::unique_ptr<InputStream> inStream(
-        new MemoryInputStream(memStream.getData(), memStream.getLength()));
+    auto inStream = std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
     std::unique_ptr<Reader> reader = createReader(pool, std::move(inStream));
     std::unique_ptr<RowReader> rowReader = createRowReader(reader.get());
     EXPECT_EQ(rowCount, reader->getNumberOfRows());
@@ -897,8 +883,7 @@ namespace orc {
 
     writer->close();
 
-    std::unique_ptr<InputStream> inStream(
-        new MemoryInputStream(memStream.getData(), memStream.getLength()));
+    auto inStream = std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
     std::unique_ptr<Reader> reader = createReader(pool, std::move(inStream));
     std::unique_ptr<RowReader> rowReader = createRowReader(reader.get());
     EXPECT_EQ((rowCount + maxPrecision) * 2, reader->getNumberOfRows());
@@ -980,8 +965,7 @@ namespace orc {
 
     writer->close();
 
-    std::unique_ptr<InputStream> inStream(
-        new MemoryInputStream(memStream.getData(), memStream.getLength()));
+    auto inStream = std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
     std::unique_ptr<Reader> reader = createReader(pool, std::move(inStream));
     std::unique_ptr<RowReader> rowReader = createRowReader(reader.get());
     EXPECT_EQ((rowCount + maxPrecision) * 2, reader->getNumberOfRows());
@@ -1055,8 +1039,7 @@ namespace orc {
     writer->add(*batch);
     writer->close();
 
-    std::unique_ptr<InputStream> inStream(
-        new MemoryInputStream(memStream.getData(), memStream.getLength()));
+    auto inStream = std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
     std::unique_ptr<Reader> reader = createReader(pool, std::move(inStream));
     std::unique_ptr<RowReader> rowReader = createRowReader(reader.get());
     EXPECT_EQ(rowCount, reader->getNumberOfRows());
@@ -1129,8 +1112,7 @@ namespace orc {
     writer->add(*batch);
     writer->close();
 
-    std::unique_ptr<InputStream> inStream(
-        new MemoryInputStream(memStream.getData(), memStream.getLength()));
+    auto inStream = std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
     std::unique_ptr<Reader> reader = createReader(pool, std::move(inStream));
     std::unique_ptr<RowReader> rowReader = createRowReader(reader.get());
     EXPECT_EQ(rowCount, reader->getNumberOfRows());
@@ -1214,8 +1196,7 @@ namespace orc {
     writer->add(*batch);
     writer->close();
 
-    std::unique_ptr<InputStream> inStream(
-        new MemoryInputStream(memStream.getData(), memStream.getLength()));
+    auto inStream = std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
     std::unique_ptr<Reader> reader = createReader(pool, std::move(inStream));
     std::unique_ptr<RowReader> rowReader = createRowReader(reader.get());
     EXPECT_EQ(rowCount, reader->getNumberOfRows());
@@ -1295,8 +1276,7 @@ namespace orc {
     writer->close();
 
     // read and verify data
-    std::unique_ptr<InputStream> inStream(
-        new MemoryInputStream(memStream.getData(), memStream.getLength()));
+    auto inStream = std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
     std::unique_ptr<Reader> reader = createReader(pool, std::move(inStream));
     std::unique_ptr<RowReader> rowReader = createRowReader(reader.get());
     EXPECT_EQ(rowCount, reader->getNumberOfRows());
@@ -1378,8 +1358,7 @@ namespace orc {
     writer->add(*batch);
     writer->close();
 
-    std::unique_ptr<InputStream> inStream(
-        new MemoryInputStream(memStream.getData(), memStream.getLength()));
+    auto inStream = std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
     std::unique_ptr<Reader> reader = createReader(pool, std::move(inStream));
     std::unique_ptr<RowReader> rowReader = createRowReader(reader.get());
     EXPECT_EQ(4, reader->getNumberOfRows());
@@ -1450,8 +1429,7 @@ namespace orc {
     writer->add(*batch);
     writer->close();
 
-    std::unique_ptr<InputStream> inStream(
-        new MemoryInputStream(memStream.getData(), memStream.getLength()));
+    auto inStream = std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
     std::unique_ptr<Reader> reader = createReader(pool, std::move(inStream));
     std::unique_ptr<RowReader> rowReader = createRowReader(reader.get());
     EXPECT_EQ(5, reader->getNumberOfRows());
@@ -1535,8 +1513,7 @@ namespace orc {
     writer->add(*batch);
     writer->close();
 
-    std::unique_ptr<InputStream> inStream(
-        new MemoryInputStream(memStream.getData(), memStream.getLength()));
+    auto inStream = std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
     std::unique_ptr<Reader> reader = createReader(pool, std::move(inStream));
     std::unique_ptr<RowReader> rowReader = createRowReader(reader.get());
     EXPECT_EQ(10000, reader->getNumberOfRows());
@@ -1688,8 +1665,7 @@ namespace orc {
     writer->close();
 
     // verify bloomfilters
-    std::unique_ptr<InputStream> inStream(
-        new MemoryInputStream(memStream.getData(), memStream.getLength()));
+    auto inStream = std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
     std::unique_ptr<Reader> reader = createReader(pool, std::move(inStream));
     EXPECT_EQ(rowCount, reader->getNumberOfRows());
 
@@ -1759,8 +1735,8 @@ namespace orc {
     }
     // read file & check the present stream
     {
-      std::unique_ptr<InputStream> inStream(
-          new MemoryInputStream(memStream.getData(), memStream.getLength()));
+      auto inStream =
+          std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
       ReaderOptions readerOptions;
       readerOptions.setMemoryPool(*pool);
       std::unique_ptr<Reader> reader = createReader(std::move(inStream), readerOptions);
@@ -1797,10 +1773,10 @@ namespace orc {
       // fetch StripeFooter from pb stream
       std::unique_ptr<StripeInformation> stripeInfo = reader->getStripe(0);
       ReaderImpl* readerImpl = dynamic_cast<ReaderImpl*>(reader.get());
-      std::unique_ptr<SeekableInputStream> pbStream(new SeekableFileInputStream(
+      auto pbStream = std::make_unique<SeekableFileInputStream>(
           readerImpl->getStream(),
           stripeInfo->getOffset() + stripeInfo->getIndexLength() + stripeInfo->getDataLength(),
-          stripeInfo->getFooterLength(), *pool));
+          stripeInfo->getFooterLength(), *pool);
       proto::StripeFooter stripeFooter;
       if (!stripeFooter.ParseFromZeroCopyStream(pbStream.get())) {
         throw ParseError("Parse stripe footer from pb stream failed");
@@ -1922,8 +1898,7 @@ namespace orc {
     writer->add(*batch);
     writer->close();
 
-    std::unique_ptr<InputStream> inStream(
-        new MemoryInputStream(memStream.getData(), memStream.getLength()));
+    auto inStream = std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
     std::unique_ptr<Reader> reader = createReader(pool, std::move(inStream));
     std::unique_ptr<RowReader> rowReader = createRowReader(reader.get(), "GMT", true);
 


### PR DESCRIPTION
make_unique and make_shared should be prefered when creating unique_ptr and shared_ptr.

a few `auto` is used in this patch to make the code shorter.

Signed-off-by: Junwang Zhao <zhjwpku@gmail.com>
