### PR TITLE
ORC-1348: [C++] TimezoneImpl constructor should pass vector ref

### DIFF
--- a/c++/src/Timezone.cc
+++ b/c++/src/Timezone.cc
@@ -565,7 +565,7 @@ namespace orc {
 
   class TimezoneImpl : public Timezone {
    public:
-    TimezoneImpl(const std::string& name, const std::vector<unsigned char> bytes);
+    TimezoneImpl(const std::string& _filename, const std::vector<unsigned char>& buffer);
     virtual ~TimezoneImpl() override;
 
     /**
@@ -633,7 +633,7 @@ namespace orc {
     // PASS
   }
 
-  TimezoneImpl::TimezoneImpl(const std::string& _filename, const std::vector<unsigned char> buffer)
+  TimezoneImpl::TimezoneImpl(const std::string& _filename, const std::vector<unsigned char>& buffer)
       : filename(_filename) {
     parseZoneFile(&buffer[0], 0, buffer.size(), Version1Parser());
     // Build the literal for the ORC epoch


### PR DESCRIPTION
timezone file might be hundreds or thousands of bytes, pass references of byte vector should be more efficient.

Signed-off-by: Junwang Zhao <zhjwpku@gmail.com>
